### PR TITLE
Add static 'concat' method to BitVector

### DIFF
--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -339,3 +339,10 @@ class BitVector:
     @property
     def unsigned_value(self):
         return self._value
+
+    # Note: In concat(x, y), the MSB of the result is the MSB of x.
+    @staticmethod
+    def concat(x, y):
+        bits = y.bits()
+        bits.extend(x.bits())
+        return BitVector(bits)

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -1,0 +1,8 @@
+from bit_vector import BitVector
+
+def test_concat():
+    a = BitVector(4, 4)
+    b = BitVector(1, 4)
+    c = BitVector.concat(a, b)
+    expected = BitVector([1,0,0,0,0,0,1,0], 8)
+    assert expected == c


### PR DESCRIPTION
Adding this method in effort to close parity gap with SMT BitVector. Also useful for the PE stuff.