### PR TITLE
Added adc and overflow. Changed zext to not wrap output type.

### DIFF
--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -124,7 +124,6 @@ class BitVector:
         else:
             raise Exception("BitVector initialization with type {} not supported".format(type(value)))
 
-        #print('BV',num_bits)
         self.num_bits = num_bits
         if self._value is not None and self._value.bit_length() > self.num_bits:
             raise Exception("BitVector initialized with too small a width")

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -415,15 +415,15 @@ class BitVector:
     def repeat(self, other):
         return BitVector( other.as_uint() * self.bits() )
 
-    @binary_no_cast
+    @binary
     def sext(self, other):
         return self.concat(BitVector(other.as_uint() * [self[-1]]), self)
 
-    @binary_no_cast
+    @binary
     def ext(self, other):
         return self.zext(other)
 
-    @binary_no_cast
+    @binary
     def zext(self, other):
         return BitVector.concat(BitVector(other.as_uint() * [0]), self)
 

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -415,15 +415,15 @@ class BitVector:
     def repeat(self, other):
         return BitVector( other.as_uint() * self.bits() )
 
-    @binary
+    @binary_no_cast
     def sext(self, other):
         return self.concat(BitVector(other.as_uint() * [self[-1]]), self)
 
-    @binary
+    @binary_no_cast
     def ext(self, other):
         return self.zext(other)
 
-    @binary
+    @binary_no_cast
     def zext(self, other):
         return BitVector.concat(BitVector(other.as_uint() * [0]), self)
 

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -490,8 +490,8 @@ class SIntVector(NumVector):
         return self.sext(other)
 
 def overflow(a, b, res):
-    msba = BitVector(a[-1],1)
-    msbb = BitVector(b[-1],1)
-    N = BitVector(res[-1],1)
-    return (msba & msbb & ~N) or (~msba & ~msbb & N)
+    msb_a = BitVector(a[-1], 1)
+    msb_b = BitVector(b[-1], 1)
+    N = BitVector(res[-1], 1)
+    return (msb_a & msb_b & ~N) or (~msb_a & ~msb_b & N)
 

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -283,12 +283,18 @@ class BitVector:
         else:
             return BitVector(~self.as_uint()+1, num_bits=self.num_bits)
 
-    # add with carry, returns result and carry
-    #   no type checks yet
     def adc(a, b, c):
+        """
+        add with carry
+
+        returns a two element tuple of the form (result, carry)
+
+        no type checks yet
+        """
         n = a.num_bits
         a = a.zext(1)
         b = b.zext(1)
+        # Extend c by the difference between c's current bit length and n + 1
         n = n + 1 - c.num_bits
         c = c.zext(n)
         res = a + b + c

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -292,7 +292,7 @@ class BitVector:
         n = n + 1 - c.num_bits
         c = c.zext(n)
         res = a + b + c
-        return res[0:-1], BitVector(res[-1],1)
+        return res[0:-1], BitVector(res[-1], 1)
 
     @binary
     def bvadd(self, other):

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -1,0 +1,20 @@
+from bit_vector import BitVector as BV
+import random
+import pytest
+
+
+adc_params = []
+
+for i in range(0, 32):
+    n = random.randint(0, 32)
+    a = BV(random.randint(0, (1 << n) - 1), n)
+    b = BV(random.randint(0, (1 << n) - 1), n)
+    c = BV(random.randint(0, 1), 1)
+    adc_params.append((a, b, c))
+
+
+@pytest.mark.parametrize("a,b,c", adc_params)
+def test_adc(a, b, c):
+    res, carry = a.adc(b, c)
+    assert res == a + b + c
+    assert carry == (a.zext(1) + b.zext(1) + c)[-1]

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -6,7 +6,7 @@ import pytest
 adc_params = []
 
 for i in range(0, 32):
-    n = random.randint(0, 32)
+    n = random.randint(1, 32)
     a = BV(random.randint(0, (1 << n) - 1), n)
     b = BV(random.randint(0, (1 << n) - 1), n)
     c = BV(random.randint(0, 1), 1)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,0 +1,38 @@
+from bit_vector import BitVector as BV
+from bit_vector import SIntVector as SV
+import random
+import pytest
+
+
+zext_params = []
+
+for i in range(0, 64):
+    n = random.randint(0, (1 << 32 - 1))
+    num_bits = random.randint(n.bit_length(), 32)
+    ext_amount = 32 - num_bits
+    zext_params.append((n, num_bits, ext_amount))
+
+
+@pytest.mark.parametrize("n,num_bits,ext_amount", zext_params)
+def test_zext(n, num_bits, ext_amount):
+    a = BV(n, num_bits)
+    assert num_bits + ext_amount == a.zext(ext_amount).num_bits
+    assert n == a.zext(ext_amount).as_uint()
+    assert BV(n, num_bits + ext_amount) == a.zext(ext_amount)
+
+
+sext_params = []
+
+for i in range(0, 64):
+    n = random.randint(-(2 ** 15), (2 ** 15) - 1)
+    num_bits = random.randint(n.bit_length() + 1, 17)
+    ext_amount = 32 - num_bits
+    sext_params.append((n, num_bits, ext_amount))
+
+
+@pytest.mark.parametrize("n,num_bits,ext_amount", sext_params)
+def test_sext(n, num_bits, ext_amount):
+    a = SV(n, num_bits)
+    assert num_bits + ext_amount == a.sext(ext_amount).num_bits
+    assert SV(n, num_bits + ext_amount).bits() == a.sext(ext_amount).bits()
+    assert SV(n, num_bits + ext_amount) == a.sext(ext_amount)

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -1,0 +1,20 @@
+from bit_vector import SIntVector as SV
+from bit_vector import overflow
+import random
+import pytest
+
+
+ovfl_params = []
+
+for i in range(0, 32):
+    n = random.randint(1, 32)
+    a = SV(random.randint(-(1 << (n - 1)), (1 << (n - 1)) - 1), n)
+    b = SV(random.randint(-(1 << (n - 1)), (1 << (n - 1)) - 1), n)
+    ovfl_params.append((a, b))
+
+
+@pytest.mark.parametrize("a,b", ovfl_params)
+def test_ovfl(a, b):
+    expected = ((a < 0) and (b < 0) and ((a + b) >= 0)) or \
+               ((a >= 0) and (b >= 0) and ((a + b) < 0))
+    assert overflow(a, b, a + b) == expected


### PR DESCRIPTION
I added these methods since they are commonly used.

In order to make them work, I modified zext and related functions to not
cast the return values. I want the extended bit vectors to be longer than
the input bit vector.