### PR TITLE
Abc

### DIFF
--- a/bit_vector/__init__.py
+++ b/bit_vector/__init__.py
@@ -1,1 +1,2 @@
 from .bit_vector import *
+from .bit_vector_abc import *

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -44,27 +44,27 @@ class Bit(AbstractBit):
             raise TypeError("Can't coerce {} to Bit".format(type(other)))
 
     def __invert__(self):
-        return Bit(not self._value)
+        return type(self)(not self._value)
 
     @bit_cast
     def __eq__(self, other):
-        return Bit(self._value == other._value)
+        return type(self)(self._value == other._value)
 
     @bit_cast
     def __ne__(self, other):
-        return Bit(self._value != other._value)
+        return type(self)(self._value != other._value)
 
     @bit_cast
     def __and__(self, other):
-        return Bit(self._value & other._value)
+        return type(self)(self._value & other._value)
 
     @bit_cast
     def __or__(self, other):
-        return Bit(self._value | other._value)
+        return type(self)(self._value | other._value)
 
     @bit_cast
     def __xor__(self, other):
-        return Bit(self._value ^ other._value)
+        return type(self)(self._value ^ other._value)
 
     def ite(self, t_branch, f_branch):
         return t_branch if self._value else f_branch
@@ -149,7 +149,7 @@ class BitVector(AbstractBitVector):
     def __getitem__(self, index : tp.Union[int, slice]) -> tp.Union['BitVector', Bit]:
         if isinstance(index, slice):
             v = self.bits()[index]
-            return BitVector[len(v)](v)
+            return type(self).unsized_t[len(v)](v)
         elif isinstance(index, int):
             if index < 0:
                 index = self.size+index
@@ -188,15 +188,15 @@ class BitVector(AbstractBitVector):
 
     @bv_cast
     def bvshl(self, other):
-        return type(self)( self.as_uint() << other.as_uint())
+        return type(self)(self.as_uint() << other.as_uint())
 
     @bv_cast
     def bvlshr(self, other):
-        return type(self)( self.as_uint() >> other.as_uint())
+        return type(self)(self.as_uint() >> other.as_uint())
 
     @bv_cast
     def bvashr(self, other):
-        return type(self)( self.as_sint() >> other.as_uint())
+        return type(self)(self.as_sint() >> other.as_uint())
 
     @bv_cast
     def bvrol(self, other):
@@ -230,7 +230,6 @@ class BitVector(AbstractBitVector):
 
         returns a two element tuple of the form (result, carry)
 
-        no type checks yet
         """
         T = type(self)
         other = _coerce(T, other)

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -1,4 +1,4 @@
-from .bit_vector_abc import BitVectorABC
+from .bit_vector_abc import AbstractBitVector
 from .compatibility import IntegerTypes, StringTypes
 import functools
 import random
@@ -102,7 +102,7 @@ def no_x(fn):
 
     return wrapped
 
-class BitVector(BitVectorABC):
+class BitVector(AbstractBitVector):
     def __init__(self, value=0, num_bits=None):
         if isinstance(value, BitVector):
             if num_bits is None:
@@ -167,7 +167,7 @@ class BitVector(BitVectorABC):
         if isinstance(index, slice):
             return BitVector(self._bits[index])
         else:
-            return self.bits()[index]
+            return BitVector(self.bits()[index], 1)
 
     def __len__(self):
         return self.num_bits

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -1,5 +1,5 @@
 import typing as tp
-from .bit_vector_abc import AbstractBitVector, AbstractBit
+from .bit_vector_abc import AbstractBitVector, AbstractBit, TypeFamily
 from .compatibility import IntegerTypes, StringTypes
 
 import functools
@@ -35,6 +35,10 @@ def bit_cast(fn : tp.Callable[['Bit', 'Bit'], 'Bit']) -> tp.Callable[['Bit', tp.
 
 
 class Bit(AbstractBit):
+    @staticmethod
+    def get_family() -> TypeFamily:
+        return _Family_
+
     def __init__(self, value):
         if isinstance(value, Bit):
             self._value = value._value
@@ -94,6 +98,10 @@ def bv_cast(fn : tp.Callable[['BitVector', 'BitVector'], tp.Any]) -> tp.Callable
     return wrapped
 
 class BitVector(AbstractBitVector):
+    @staticmethod
+    def get_family() -> TypeFamily:
+        return _Family_
+
     def __init__(self, value=0):
         if isinstance(value, BitVector):
             if value.size > self.size:
@@ -437,3 +445,4 @@ def overflow(a, b, res):
     N = res[-1]
     return (msb_a & msb_b & ~N) or (~msb_a & ~msb_b & N)
 
+_Family_ = TypeFamily(Bit, BitVector, UIntVector, SIntVector)

--- a/bit_vector/bit_vector.py
+++ b/bit_vector/bit_vector.py
@@ -280,14 +280,12 @@ class BitVector(AbstractBitVector):
     def bvudiv(self, other):
         other = other.as_uint()
         if other == 0:
-            return type(self)[1]
+            return type(self)((1 << self.size) - 1)
         return type(self)(self.as_uint() // other)
 
     @binary
     def bvurem(self, other):
         other = other.as_uint()
-        if other == 0:
-            return self
         return type(self)(self.as_uint() % other)
 
     # bvumod
@@ -296,14 +294,12 @@ class BitVector(AbstractBitVector):
     def bvsdiv(self, other):
         other = other.as_sint()
         if other == 0:
-            return type(self)(1)
+            return type(self)((1 << self.size) - 1)
         return type(self)(self.as_sint() // other)
 
     @binary
     def bvsrem(self, other):
         other = other.as_sint()
-        if other == 0:
-            return self
         return type(self)(self.as_sint() % other)
 
     # bvsmod
@@ -372,7 +368,7 @@ class BitVector(AbstractBitVector):
 
     @binary
     def repeat(self, other):
-        return BitVector( other.as_uint() * self.bits() )
+        return BitVector[other.as_uint() * self.size]( other.as_uint() * self.bits() )
 
     @binary_no_cast
     def sext(self, other):
@@ -408,7 +404,8 @@ class BitVector(AbstractBitVector):
         **NOTE:** Does not cast, returns a raw BitVector instead.  See
         docstring for `sext` for more info.
         """
-        return self.concat(BitVector[other.as_uint()](0), self)
+        ext = other.as_uint()
+        return self.concat(BitVector[ext](0), self)
 
     @staticmethod
     def random(width):

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -115,6 +115,10 @@ class BitVectorABC(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def ite(i,t,e):
+        pass
+
+    @abstractmethod
     def bvadd(self, other):
         pass
 

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -16,9 +16,9 @@ class AbstractBitVectorMeta(ABCMeta):
             raise TypeError('Cannot use old style construction on sized types')
         elif cls.is_sized:
             return super().__call__(value)
-        elif size is None:
-            warnings.warn('DEPRECATION WARNING: Use of BitVectorT(value, size) is deprecated')
         elif size is _MISSING or size is None:
+            if size is None:
+                warnings.warn('DEPRECATION WARNING: Use of BitVectorT(value, size) is deprecated')
             if isinstance(value, AbstractBitVector):
                 size = value.size
             elif isinstance(value, AbstractBit):

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -12,6 +12,8 @@ class AbstractBitVectorMeta(ABCMeta):
 
         if not isinstance(idx, int):
             raise TypeError()
+        if idx < 0:
+            raise ValueError('Size of BitVectors must be positive')
 
         if not getattr(cls._size, '__isabstractmethod__', False):
             raise TypeError('Cannot generate sized from sized')

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -1,0 +1,158 @@
+from abc import ABCMeta, abstractmethod
+import typing as tp
+
+class BitVectorABC(metaclass=ABCMeta):
+
+    @abstractmethod
+    def make_constant(self, value, num_bits:tp.Optional[int]=None):
+        pass
+
+    @abstractmethod
+    def __getitem__(self, index):
+        pass
+
+    @abstractmethod
+    def __setitem__(self, index, value):
+        pass
+
+    @abstractmethod
+    def __len__(self):
+        pass
+
+    #could still be staticmethod but I think thats annoying
+    @classmethod
+    @abstractmethod
+    def concat(cls, x, y):
+        pass
+
+    @abstractmethod
+    def bvnot(self):
+        pass
+
+    @abstractmethod
+    def bvand(self, other):
+        pass
+
+    def bvnand(self, other):
+        return self.bvand(other).bvnot()
+
+    @abstractmethod
+    def bvor(self, other):
+        pass
+
+    def bvnor(self, other):
+        return self.bvor(other).bvnot()
+
+    @abstractmethod
+    def bvxor(self, other):
+        pass
+
+    def bvxnor(self, other):
+        return self.bvxor(other).bvnot()
+
+    @abstractmethod
+    def bvshl(self, other):
+        pass
+
+    @abstractmethod
+    def bvlshr(self, other):
+        pass
+
+    @abstractmethod
+    def bvashr(self, other):
+        pass
+
+    @abstractmethod
+    def bvrol(self, other):
+        pass
+
+    @abstractmethod
+    def bvror(self, other):
+        pass
+
+    @abstractmethod
+    def bvcomp(self, other):
+        pass
+
+    def bveq(self, other):
+        return self.bvcomp(other)
+
+    def bvne(self, other):
+        return self.bvcomp(other).bvnot()
+
+    @abstractmethod
+    def bvult(self, other):
+        pass
+
+    def bvule(self, other):
+        return self.bvult(other).bvor(self.bvcomp(other))
+
+    def bvugt(self, other):
+        return self.bvule(other).bvnot()
+
+    def bvuge(self, other):
+        return self.bvult(other).bvnot()
+
+    @abstractmethod
+    def bvslt(self, other):
+        pass
+
+    def bvsle(self, other):
+        return self.bvslt(other).bvor(self.bvcomp(other))
+
+    def bvsgt(self, other):
+        return self.bvsle(other).bvnot()
+
+    def bvsge(self, other):
+        return self.bvslt(other).bvnot()
+
+    @abstractmethod
+    def bvneg(self):
+        pass
+
+    @abstractmethod
+    def adc(self, other, carry):
+        pass
+
+    @abstractmethod
+    def bvadd(self, other):
+        pass
+
+    def bvsub(self, other):
+        return self.bvadd(other.bvneg())
+
+    @abstractmethod
+    def bvmul(self, other):
+        pass
+
+    @abstractmethod
+    def bvudiv(self, other):
+        pass
+
+    @abstractmethod
+    def bvurem(self, other):
+        pass
+
+    @abstractmethod
+    def bvsdiv(self, other):
+        pass
+
+    @abstractmethod
+    def bvsrem(self, other):
+        pass
+
+    @abstractmethod
+    def repeat(self, other):
+        pass
+
+    @abstractmethod
+    def sext(self, other):
+        pass
+
+    @abstractmethod
+    def ext(self, other):
+        pass
+
+    @abstractmethod
+    def zext(self, other):
+        pass

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -18,12 +18,10 @@ class AbstractBitVectorMeta(ABCMeta):
         if not getattr(cls._size, '__isabstractmethod__', False):
             raise TypeError('Cannot generate sized from sized')
 
-
-        if cls is AbstractBitVector:
-            bases = (cls,)
-        else:
-            bases = (cls, AbstractBitVector[idx])
-
+        bases = [cls]
+        if cls is not AbstractBitVector:
+            bases.extend(b[idx] for b in cls.__bases__ if isinstance(b, AbstractBitVectorMeta))
+        bases = tuple(bases)
         class_name = '{}[{}]'.format(cls.__name__, idx)
         def size(self):
             return idx

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -19,8 +19,7 @@ class AbstractBitVectorMeta(ABCMeta):
             raise TypeError('Cannot generate sized from sized')
 
         bases = [cls]
-        if cls is not AbstractBitVector:
-            bases.extend(b[idx] for b in cls.__bases__ if isinstance(b, AbstractBitVectorMeta))
+        bases.extend(b[idx] for b in cls.__bases__ if isinstance(b, AbstractBitVectorMeta))
         bases = tuple(bases)
         class_name = '{}[{}]'.format(cls.__name__, idx)
         def size(self):

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 import typing as tp
 
-class BitVectorABC(metaclass=ABCMeta):
+class AbstractBitVector(metaclass=ABCMeta):
 
     @abstractmethod
     def make_constant(self, value, num_bits:tp.Optional[int]=None):
@@ -9,10 +9,6 @@ class BitVectorABC(metaclass=ABCMeta):
 
     @abstractmethod
     def __getitem__(self, index):
-        pass
-
-    @abstractmethod
-    def __setitem__(self, index, value):
         pass
 
     @abstractmethod

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -22,7 +22,7 @@ class AbstractBitVectorMeta(ABCMeta):
         else:
             bases = (cls, AbstractBitVector[idx])
 
-        class_name = f'{cls.__name__}[{idx}]'
+        class_name = '{}[{}]'.format(cls.__name__, idx)
         def size(self):
             return idx
         t = type(cls)(class_name, bases, {'_size' : size})

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 import typing as tp
+import functools as ft
 import weakref
 
 class AbstractBitVectorMeta(ABCMeta):
@@ -96,14 +97,26 @@ class AbstractBitVector(metaclass=AbstractBitVectorMeta):
         if cls.is_sized:
             return super().__new__(cls)
 
-        value = int(value)
-        size = value.bit_length()
+        if isinstance(value, AbstractBitVector):
+            size = value.size
+        elif isinstance(value, AbstractBit):
+            size = 1
+        elif isinstance(value, tp.Sequence):
+            size = max(len(value), 1)
+        elif isinstance(value, int):
+            size = max(value.bit_length(), 1)
+        elif hasattr(value, '__int__'):
+            size = max(int(value).bit_length(), 1)
+        else:
+            raise TypeError('Cannot construct {} from {}'.format(cls, value))
+
         return cls[size].__new__(cls[size], value)
 
     @property
     def size(self) -> int:
         return  type(self).size
 
+    @classmethod
     @abstractmethod
     def make_constant(self, value, num_bits:tp.Optional[int]=None) -> 'AbstractBitVector':
         pass

--- a/bit_vector/bit_vector_abc.py
+++ b/bit_vector/bit_vector_abc.py
@@ -1,8 +1,12 @@
 from abc import ABCMeta, abstractmethod
+from collections import namedtuple
 import typing as tp
 import functools as ft
 import weakref
 import warnings
+
+
+TypeFamily = namedtuple('TypeFamily', ['Bit', 'BitVector', 'Unsigned', 'Signed'])
 
 #I want to be able differentiate an old style call
 #BitVector(val, None) from BitVector(val)
@@ -96,6 +100,10 @@ class AbstractBitVectorMeta(ABCMeta):
         return AbstractBitVectorMeta._class_info[cls][1] is not None
 
 class AbstractBit(metaclass=ABCMeta):
+    @staticmethod
+    def get_family() -> TypeFamily:
+        return _Family_
+
     @abstractmethod
     def __eq__(self, other) -> 'AbstractBit':
         pass
@@ -124,6 +132,10 @@ class AbstractBit(metaclass=ABCMeta):
         pass
 
 class AbstractBitVector(metaclass=AbstractBitVectorMeta):
+    @staticmethod
+    def get_family() -> TypeFamily:
+        return _Family_
+
     @property
     def size(self) -> int:
         return  type(self).size
@@ -282,3 +294,6 @@ class AbstractBitVector(metaclass=AbstractBitVectorMeta):
     @abstractmethod
     def zext(self, other) -> 'AbstractBitVector':
         pass
+
+
+_Family_ = TypeFamily(AbstractBit, AbstractBitVector, None, None)

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -7,9 +7,9 @@ adc_params = []
 
 for i in range(0, 32):
     n = random.randint(1, 32)
-    a = BV(random.randint(0, (1 << n) - 1), n)
-    b = BV(random.randint(0, (1 << n) - 1), n)
-    c = BV(random.randint(0, 1), 1)
+    a = BV[n](random.randint(0, (1 << n) - 1))
+    b = BV[n](random.randint(0, (1 << n) - 1))
+    c = BV[1](random.randint(0, 1))
     adc_params.append((a, b, c))
 
 
@@ -20,9 +20,9 @@ def test_adc(a, b, c):
     assert carry == (a.zext(1) + b.zext(1) + c)[-1]
 
 def test_adc1():
-    a = BV(27734,num_bits=16)
-    b = BV(13207,num_bits=16)
-    c = BV(0,num_bits=1)
+    a = BV[16](27734)
+    b = BV[16](13207)
+    c = BV[1](0)
     res, carry = a.adc(b, c)
     assert res == a + b + c
     assert carry == (a.zext(1) + b.zext(1) + c)[-1]

--- a/tests/test_adc.py
+++ b/tests/test_adc.py
@@ -16,13 +16,13 @@ for i in range(0, 32):
 @pytest.mark.parametrize("a,b,c", adc_params)
 def test_adc(a, b, c):
     res, carry = a.adc(b, c)
-    assert res == a + b + c
-    assert carry == (a.zext(1) + b.zext(1) + c)[-1]
+    assert res == a + b + c.zext(a.size - c.size)
+    assert carry == (a.zext(1) + b.zext(1) + c.zext(1 + a.size - c.size))[-1]
 
 def test_adc1():
     a = BV[16](27734)
     b = BV[16](13207)
     c = BV[1](0)
     res, carry = a.adc(b, c)
-    assert res == a + b + c
-    assert carry == (a.zext(1) + b.zext(1) + c)[-1]
+    assert res == a + b + c.zext(a.size - c.size)
+    assert carry == (a.zext(1) + b.zext(1) + c.zext(1 + a.size - c.size))[-1]

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -6,7 +6,7 @@ NTESTS = 4
 WIDTHS = [1,2,4,8]
 
 def unsigned(value, width):
-    return BitVector(value, width)
+    return BitVector[width](value)
 
 @pytest.mark.parametrize("op, reference", [
                               (operator.invert, lambda x: ~x),
@@ -35,7 +35,7 @@ def test_operator_bit2(op, reference, width):
         assert expected == int(op(I0, I1))
 
 def test_as():
-    bv = BitVector(1,4)
+    bv = BitVector[4](1)
     assert bv.as_sint() == 1
     assert bv.as_uint() == 1
     assert int(bv) == 1
@@ -43,22 +43,22 @@ def test_as():
     assert bv.bits() == [1,0,0,0]
     assert bv.as_binary_string()== '0b0001'
     assert str(bv) == '1'
-    assert repr(bv) == 'BitVector(1, 4)'
+    assert repr(bv) == 'BitVector[4](1)'
 
 def test_eq():
-    assert BitVector(1,4) == 1
-    assert BitVector(1,4) == BitVector(1,4)
-    assert [BitVector(1,4)] == [BitVector(1,4)]
-    assert [[BitVector(1,4)]] == [[BitVector(1,4)]]
+    assert BitVector[4](1) == 1
+    assert BitVector[4](1) == BitVector[4](1)
+    assert [BitVector[4](1)] == [BitVector[4](1)]
+    assert [[BitVector[4](1)]] == [[BitVector[4](1)]]
 
-    assert BitVector(None,1) == BitVector(None,1) 
+    assert BitVector[1](None) == BitVector[1](None)
 
 def test_setitem():
   bv = BitVector(5)
   assert bv.as_uint() ==5
   bv[0] = 0
-  assert repr(bv) == 'BitVector(4, 3)'
+  assert repr(bv) == 'BitVector[3](4)'
   bv[1] = 1
-  assert repr(bv) == 'BitVector(6, 3)'
+  assert repr(bv) == 'BitVector[3](6)'
   bv[2] = 0
-  assert repr(bv) == 'BitVector(2, 3)'
+  assert repr(bv) == 'BitVector[3](2)'

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -1,6 +1,6 @@
 import pytest
 import operator
-from bit_vector import BitVector
+from bit_vector import BitVector, Bit
 
 NTESTS = 4
 WIDTHS = [1,2,4,8]
@@ -19,8 +19,6 @@ def test_operator_bit1(op, reference, width):
         assert expected == int(op(I))
 
 @pytest.mark.parametrize("op, reference", [
-                              (operator.eq, lambda x, y: x == y),
-                              (operator.ne, lambda x, y: x != y),
                               (operator.and_,   lambda x, y: x & y ),
                               (operator.or_,    lambda x, y: x | y ),
                               (operator.xor,    lambda x, y: x ^ y ),
@@ -33,6 +31,21 @@ def test_operator_bit2(op, reference, width):
         I0, I1 = BitVector.random(width), BitVector.random(width)
         expected = unsigned(reference(int(I0), int(I1)), width)
         assert expected == int(op(I0, I1))
+
+@pytest.mark.parametrize("op, reference", [
+                              (operator.eq, lambda x, y: x == y),
+                              (operator.ne, lambda x, y: x != y),
+                              (operator.lt, lambda x, y: x  < y),
+                              (operator.le, lambda x, y: x <= y),
+                              (operator.gt, lambda x, y: x  > y),
+                              (operator.ge, lambda x, y: x >= y),
+                              ])
+@pytest.mark.parametrize("width", WIDTHS)
+def test_comparisons(op, reference, width):
+    for _ in range(NTESTS):
+        I0, I1 = BitVector.random(width), BitVector.random(width)
+        expected = Bit(reference(int(I0), int(I1)))
+        assert expected == bool(op(I0, I1))
 
 def test_as():
     bv = BitVector[4](1)

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -64,7 +64,6 @@ def test_eq():
     assert [BitVector[4](1)] == [BitVector[4](1)]
     assert [[BitVector[4](1)]] == [[BitVector[4](1)]]
 
-    assert BitVector[1](None) == BitVector[1](None)
 
 def test_setitem():
   bv = BitVector(5)

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -1,8 +1,8 @@
 from bit_vector import BitVector
 
 def test_concat():
-    a = BitVector(4, 4)
-    b = BitVector(1, 4)
+    a = BitVector[4](4)
+    b = BitVector[4](1)
     c = BitVector.concat(a, b)
-    expected = BitVector([1,0,0,0,0,0,1,0])
+    expected = BitVector[8]([1,0,0,0,0,0,1,0])
     assert expected == c

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -1,0 +1,22 @@
+from bit_vector import BitVector as BV
+import random
+import pytest
+
+
+div_params = [(32, 0xdeadbeaf, 0)]
+
+for i in range(0, 32):
+    n = random.randint(1, 32)
+    a = random.randint(0, (1 << n) - 1)
+    b = random.randint(0, (1 << n) - 1)
+    div_params.append((n, a, b))
+
+@pytest.mark.parametrize("n,a,b", div_params)
+def test_div(n, a, b):
+    if b != 0:
+        res = a // b
+    else:
+        res = (1 << n) - 1
+
+    assert res == (BV[n](a) // BV[n](b)).as_uint()
+

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -15,10 +15,10 @@ for i in range(0, 64):
 
 @pytest.mark.parametrize("n,num_bits,ext_amount", zext_params)
 def test_zext(n, num_bits, ext_amount):
-    a = BV(n, num_bits)
+    a = BV[num_bits](n)
     assert num_bits + ext_amount == a.zext(ext_amount).num_bits
     assert n == a.zext(ext_amount).as_uint()
-    assert BV(n, num_bits + ext_amount) == a.zext(ext_amount)
+    assert BV[num_bits + ext_amount](n) == a.zext(ext_amount)
 
 
 sext_params = []
@@ -32,7 +32,7 @@ for i in range(0, 64):
 
 @pytest.mark.parametrize("n,num_bits,ext_amount", sext_params)
 def test_sext(n, num_bits, ext_amount):
-    a = SV(n, num_bits)
+    a = SV[num_bits](n)
     assert num_bits + ext_amount == a.sext(ext_amount).num_bits
-    assert SV(n, num_bits + ext_amount).bits() == a.sext(ext_amount).bits()
-    assert SV(n, num_bits + ext_amount) == a.sext(ext_amount)
+    assert SV[num_bits + ext_amount](n).bits() == a.sext(ext_amount).bits()
+    assert SV[num_bits + ext_amount](n) == a.sext(ext_amount)

--- a/tests/test_ite.py
+++ b/tests/test_ite.py
@@ -15,5 +15,5 @@ for i in range(0, 32):
 
 @pytest.mark.parametrize("a,b,c", ite_params)
 def test_ite(a, b, c):
-    res = a.ite(b, c)
-    assert res == b if int(a) else c
+    res = c.ite(a, b)
+    assert res == (a if int(c) else b)

--- a/tests/test_ite.py
+++ b/tests/test_ite.py
@@ -7,9 +7,9 @@ ite_params = []
 
 for i in range(0, 32):
     n = random.randint(1, 32)
-    a = BV(random.randint(0, (1 << n) - 1), n)
-    b = BV(random.randint(0, (1 << n) - 1), n)
-    c = BV(random.randint(0, 1), 1)
+    a = BV[n](random.randint(0, (1 << n) - 1))
+    b = BV[n](random.randint(0, (1 << n) - 1))
+    c = BV[1](random.randint(0, 1))
     ite_params.append((a, b, c))
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,10 +1,13 @@
+import pytest
 from bit_vector import AbstractBitVector as ABV
+from bit_vector import BitVector as BV
 
-def test_meta():
+def test_subclass():
     class A(ABV): pass
     class B(ABV): pass
     class C(A): pass
     class D(A, B): pass
+    class E(ABV[8]): pass
 
     assert issubclass(A, ABV)
     assert issubclass(A[8], ABV)
@@ -25,5 +28,57 @@ def test_meta():
     assert issubclass(D[8], ABV[8])
 
 
+    assert issubclass(E, ABV[8])
+    assert issubclass(E, ABV)
+
+    with pytest.raises(TypeError):
+        ABV[8][2]
+
+    with pytest.raises(TypeError):
+        E[2]
+
+    with pytest.raises(TypeError):
+        class F(ABV[8], ABV[7]): pass
 
 
+def test_size():
+    class A(ABV): pass
+
+    assert A.size is None
+    assert A.unsized_t is A
+    bv = A[8]
+    assert bv.size == 8
+    assert bv.unsized_t is A
+
+    class B(ABV[8]): pass
+
+    assert B.size == 8
+    assert B.unsized_t is None
+    with pytest.raises(TypeError):
+        B[2]
+
+    class C(A, B): pass
+    assert C.size == 8
+    assert C.unsized_t is None
+    with pytest.raises(TypeError):
+        C[6]
+
+    x = BV(5)
+    assert x.size == 3
+    assert type(x).size == 3
+
+def test_instance():
+    x = BV[8](0)
+    assert isinstance(x, ABV)
+    assert isinstance(x, ABV[8])
+    assert isinstance(x, BV)
+    with pytest.raises(TypeError):
+        ABV[4](0)
+
+    class A(BV): pass
+
+    y = A[8](0)
+    assert isinstance(y, ABV)
+    assert isinstance(y, ABV[8])
+    assert isinstance(y, BV)
+    assert isinstance(y, BV[8])

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,29 @@
+from bit_vector import AbstractBitVector as ABV
+
+def test_meta():
+    class A(ABV): pass
+    class B(ABV): pass
+    class C(A): pass
+    class D(A, B): pass
+
+    assert issubclass(A, ABV)
+    assert issubclass(A[8], ABV)
+    assert issubclass(A[8], ABV[8])
+    assert not issubclass(A, ABV[8])
+    assert not issubclass(A[7], ABV[8])
+
+    assert issubclass(C[8], A)
+    assert issubclass(C[8], ABV)
+    assert issubclass(C[8], A[8])
+    assert issubclass(C[8], ABV[8])
+
+    assert issubclass(D[8], A)
+    assert issubclass(D[8], B)
+    assert issubclass(D[8], ABV)
+    assert issubclass(D[8], A[8])
+    assert issubclass(D[8], B[8])
+    assert issubclass(D[8], ABV[8])
+
+
+
+

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -53,13 +53,17 @@ def test_size():
     class B(ABV[8]): pass
 
     assert B.size == 8
-    assert B.unsized_t is None
+    with pytest.raises(AttributeError):
+        B.unsized_t
+
     with pytest.raises(TypeError):
         B[2]
 
     class C(A, B): pass
     assert C.size == 8
-    assert C.unsized_t is None
+    with pytest.raises(AttributeError):
+        C.unsized_t
+
     with pytest.raises(TypeError):
         C[6]
 

--- a/tests/test_overflow.py
+++ b/tests/test_overflow.py
@@ -8,8 +8,8 @@ ovfl_params = []
 
 for i in range(0, 32):
     n = random.randint(1, 32)
-    a = SV(random.randint(-(1 << (n - 1)), (1 << (n - 1)) - 1), n)
-    b = SV(random.randint(-(1 << (n - 1)), (1 << (n - 1)) - 1), n)
+    a = SV[n](random.randint(-(1 << (n - 1)), (1 << (n - 1)) - 1))
+    b = SV[n](random.randint(-(1 << (n - 1)), (1 << (n - 1)) - 1))
     ovfl_params.append((a, b))
 
 

--- a/tests/test_sint.py
+++ b/tests/test_sint.py
@@ -4,7 +4,7 @@ import random
 from bit_vector import UIntVector, SIntVector
 
 def signed(value, width):
-    return SIntVector(value, width).as_sint()
+    return SIntVector[width](value).as_sint()
 
 NTESTS = 4
 WIDTHS = [8]
@@ -57,8 +57,8 @@ def test_operator_int_shift(op, reference, width):
         assert expected == int(op(I0, I1))
 
 def test_signed():
-    a = SIntVector(4, 4)
+    a = SIntVector[4](4)
     assert int(a) == 4
-    a = SIntVector(-4, 4)
+    a = SIntVector[4](-4)
     assert a._value != 4, "Stored as unsigned two's complement value"
     assert int(a) == -4, "int returns the native signed int representation"

--- a/tests/test_uint.py
+++ b/tests/test_uint.py
@@ -1,6 +1,6 @@
 import pytest
 import operator
-from bit_vector import UIntVector
+from bit_vector import UIntVector, Bit
 
 def unsigned(value, width):
     return UIntVector[width](value).as_uint()
@@ -20,12 +20,6 @@ def test_operator_uint1(op, reference, width):
         assert expected == int(op(I))
 
 @pytest.mark.parametrize("op, reference", [
-                              (operator.eq, lambda x, y: x == y),
-                              (operator.ne, lambda x, y: x != y),
-                              (operator.lt, lambda x, y: x <  y),
-                              (operator.le, lambda x, y: x <= y),
-                              (operator.gt, lambda x, y: x >  y),
-                              (operator.ge, lambda x, y: x >= y),
                               (operator.and_,   lambda x, y: x & y ),
                               (operator.or_,    lambda x, y: x | y ),
                               (operator.xor,    lambda x, y: x ^ y ),
@@ -34,7 +28,7 @@ def test_operator_uint1(op, reference, width):
                               (operator.add,    lambda x, y: x + y ),
                               (operator.sub,    lambda x, y: x - y ),
                               (operator.mul,    lambda x, y: x * y ),
-                              (operator.floordiv,    lambda x, y: x // y if y != 0 else 1 ),
+                              (operator.floordiv,    lambda x, y: x // y if y != 0 else -1),
                           ])
 @pytest.mark.parametrize("width", WIDTHS)
 def test_operator_uint2(op, reference, width):
@@ -42,6 +36,21 @@ def test_operator_uint2(op, reference, width):
         I0, I1 = UIntVector.random(width), UIntVector.random(width)
         expected = unsigned(reference(int(I0), int(I1)), width)
         assert expected == int(op(I0, I1))
+
+@pytest.mark.parametrize("op, reference", [
+                              (operator.eq, lambda x, y: x == y),
+                              (operator.ne, lambda x, y: x != y),
+                              (operator.lt, lambda x, y: x <  y),
+                              (operator.le, lambda x, y: x <= y),
+                              (operator.gt, lambda x, y: x >  y),
+                              (operator.ge, lambda x, y: x >= y),
+                          ])
+@pytest.mark.parametrize("width", WIDTHS)
+def test_operator_comparison(op, reference, width):
+    for _ in range(NTESTS):
+        I0, I1 = UIntVector.random(width), UIntVector.random(width)
+        expected = Bit(reference(int(I0), int(I1)))
+        assert expected == bool(op(I0, I1))
 
 def test_unsigned():
     a = UIntVector[4](4)

--- a/tests/test_uint.py
+++ b/tests/test_uint.py
@@ -3,7 +3,7 @@ import operator
 from bit_vector import UIntVector
 
 def unsigned(value, width):
-    return UIntVector(value, width).as_uint()
+    return UIntVector[width](value).as_uint()
 
 NTESTS = 4
 WIDTHS = [8]
@@ -44,5 +44,5 @@ def test_operator_uint2(op, reference, width):
         assert expected == int(op(I0, I1))
 
 def test_unsigned():
-    a = UIntVector(4, 4)
+    a = UIntVector[4](4)
     assert int(a) == 4


### PR DESCRIPTION
Adds `bit_vector_abc.py` with classes `AbstractBitVector` and `AbstractBitVectorMeta`

Forces BitVector types to be bound to a specific size using the syntax `BitVectorT[size]`

Construction of BitVectors from `int` with implicit size  is still supported

Uses "abstractness" of the method `_size` to determine if a BitVector type is bound to a size.  It might be more appropriate to add some other attribute or inherit from some marker class instead.

