### PR TITLE
Fp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: python
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+    - libmpfr-dev
+    - libmpc-dev
 python:
 - '3.6'
 install:

--- a/hwtypes/__init__.py
+++ b/hwtypes/__init__.py
@@ -3,3 +3,5 @@ from .bit_vector_abc import *
 from .adt import *
 from .smt_bit_vector import *
 from .z3_bit_vector import *
+from .fp_vector_abc import *
+from .fp_vector import *

--- a/hwtypes/fp_vector.py
+++ b/hwtypes/fp_vector.py
@@ -207,9 +207,8 @@ class FPVector(AbstractFPVector):
         sign_bit = BitVector[1](gmpy2.is_signed(self._value))
         v = self._value
 
-        mantissa_str, exp, _ = v.digits(2,cls.mantissa_size + 1)
-        exp = exp - 1
-        mantissa_int = int(mantissa_str, 2)
+        mantissa_int, exp =  v.as_mantissa_exp()
+        exp = exp + cls.mantissa_size
         if mantissa_int == 0:
             return BitVector.concat(sign_bit, BitVector[cls.size-1](0))
 

--- a/hwtypes/fp_vector.py
+++ b/hwtypes/fp_vector.py
@@ -194,7 +194,6 @@ class FPVector(AbstractFPVector):
     def to_ubv(self, size : int) -> BitVector:
         return BitVector[size](int(self._value))
 
-
     @set_context
     def to_sbv(self, size : int) -> SIntVector:
         return SIntVector[size](int(self._value))
@@ -203,6 +202,7 @@ class FPVector(AbstractFPVector):
         raise NotImplementedError()
 
     def __neg__(self): return self.fp_neg()
+    def __abs__(self): return self.fp_abs()
     def __add__(self, other): return self.fp_add(other)
     def __sub__(self, other): return self.fp_sub(other)
     def __mul__(self, other): return self.fp_mul(other)
@@ -216,3 +216,5 @@ class FPVector(AbstractFPVector):
     def __le__(self, other): return self.fp_leq(other)
     def __lt__(self, other): return self.fp_lt(other)
 
+    def __float__(self):
+        return float(self._value)

--- a/hwtypes/fp_vector.py
+++ b/hwtypes/fp_vector.py
@@ -1,0 +1,218 @@
+import typing as tp
+import functools
+import gmpy2
+
+from .fp_vector_abc import AbstractFPVector, RoundingMode
+from .bit_vector import Bit, BitVector, SIntVector
+
+_mode_2_gmpy2 = {
+    RoundingMode.RNE : gmpy2.RoundToNearest,
+    RoundingMode.RNA : gmpy2.RoundAwayZero,
+    RoundingMode.RTP : gmpy2.RoundUp,
+    RoundingMode.RTN : gmpy2.RoundDown,
+    RoundingMode.RTZ : gmpy2.RoundToZero,
+}
+
+def _coerce(T : tp.Type['FPVector'], val : tp.Any) -> 'FPVector':
+    if not isinstance(val, FPVector):
+        return T(val)
+    elif type(val).info != T.info:
+        raise TypeError('Inconsistent FP type')
+    else:
+        return val
+
+def fp_cast(fn : tp.Callable[['FPVector', 'FPVector'], tp.Any]) -> tp.Callable[['FPVector', tp.Any], tp.Any]:
+    @functools.wraps(fn)
+    def wrapped(self : 'FPVector', other : tp.Any) -> tp.Any:
+        other = _coerce(type(self), other)
+        return fn(self, other)
+    return wrapped
+
+def set_context(fn: tp.Callable) -> tp.Callable:
+    @functools.wraps(fn)
+    def wrapped(self : 'FPVector', *args, **kwargs):
+        with gmpy2.local_context(self._ctx):
+            return fn(self, *args, **kwargs)
+    return wrapped
+
+class FPVector(AbstractFPVector):
+    def __init__(self, value):
+        cls = type(self)
+        if cls.ieee_compliance:
+            precision=cls.mantissa_size+1
+            emax=2**(cls.exponent_size - 1)
+            emin=4-emax-precision
+            subnormalize=True
+        else:
+            precision=cls.mantissa_size+1
+            emax=2**(cls.exponent_size - 1)
+            emin=3-emax
+            subnormalize=False
+
+        self._ctx = ctx = gmpy2.context(
+                precision=precision,
+                emin=emin,
+                emax=emax,
+                round=_mode_2_gmpy2[cls.mode],
+                subnormalize=cls.ieee_compliance,
+                allow_complex=False,
+        )
+
+        with gmpy2.local_context(ctx):
+            value = gmpy2.mpfr(value)
+            if gmpy2.is_nan(value) and not cls.ieee_compliance:
+                if gmpy2.is_signed(value):
+                    self._value = gmpy2.mpfr('-0')
+                else:
+                    self._value = gmpy2.mpfr('0')
+
+            else:
+                self._value = value
+
+    def __repr__(self):
+        return f'{self._value}'
+
+    @set_context
+    def fp_abs(self) -> 'FPVector':
+        v = self._value
+        return type(self)(v if v >= 0 else -v)
+
+    @set_context
+    def fp_neg(self) -> 'FPVector':
+        return type(self)(-self._value)
+
+    @set_context
+    @fp_cast
+    def fp_add(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(self._value + other._value)
+
+    @set_context
+    @fp_cast
+    def fp_sub(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(self._value - other._value)
+
+    @set_context
+    @fp_cast
+    def fp_mul(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(self._value * other._value)
+
+    @set_context
+    @fp_cast
+    def fp_div(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(self._value / other._value)
+
+    @set_context
+    def fp_fma(self, coef, offset) -> 'FPVector':
+        cls = type(self)
+        coef = _coerce(cls, coef)
+        offset = _coerce(cls, offset)
+        return cls(gmpy2.fma(self._value, coef._value, offset._value))
+
+    @set_context
+    def fp_sqrt(self) -> 'FPVector':
+        return type(self)(gmpy2.sqrt(self._value))
+
+    @set_context
+    @fp_cast
+    def fp_rem(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(gmpy2.remainder(self._value, other._value))
+
+    @set_context
+    def fp_round_to_integral(self) -> 'FPVector':
+        return type(self)(gmpy2.rint(self._value))
+
+    @set_context
+    @fp_cast
+    def fp_min(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(gmpy2.minnum(self._value, other._value))
+
+    @set_context
+    @fp_cast
+    def fp_max(self, other : 'FPVector') -> 'FPVector':
+        return type(self)(gmpy2.maxnum(self._value, other._value))
+
+    @set_context
+    @fp_cast
+    def fp_leq(self, other : 'FPVector') -> Bit:
+        return Bit(self._value <= other._value)
+
+    @set_context
+    @fp_cast
+    def fp_lt(self, other : 'FPVector') ->  Bit:
+        return Bit(self._value < other._value)
+
+    @set_context
+    @fp_cast
+    def fp_geq(self, other : 'FPVector') ->  Bit:
+        return Bit(self._value >= other._value)
+
+    @set_context
+    @fp_cast
+    def fp_gt(self, other : 'FPVector') ->  Bit:
+        return Bit(self._value > other._value)
+
+    @set_context
+    @fp_cast
+    def fp_eq(self, other : 'FPVector') ->  Bit:
+        return Bit(self._value == other._value)
+
+    @set_context
+    def fp_is_normal(self) -> Bit:
+        if not type(self).ieee_compliance:
+            return Bit(True)
+        else:
+            raise NotImplementedError()
+
+    @set_context
+    def fp_is_subnormal(self) -> Bit:
+        if not type(self).ieee_compliance:
+            return Bit(False)
+        else:
+            raise NotImplementedError()
+
+    @set_context
+    def fp_is_zero(self) -> Bit:
+        return Bit(gmpy2.is_zero(self._value))
+
+    @set_context
+    def fp_is_infinite(self) -> Bit:
+        return Bit(gmpy2.is_infinite(self._value))
+
+    @set_context
+    def fp_is_NaN(self) -> Bit:
+        return Bit(gmpy2.is_nan(self._value))
+
+    @set_context
+    def fp_is_negative(self) -> Bit:
+        return Bit(self._value < 0)
+
+    @set_context
+    def fp_is_positive(self) -> Bit:
+        return Bit(self._value > 0)
+
+    @set_context
+    def to_ubv(self, size : int) -> BitVector:
+        return BitVector[size](int(self._value))
+
+
+    @set_context
+    def to_sbv(self, size : int) -> SIntVector:
+        return SIntVector[size](int(self._value))
+
+    def reinterpret_as_bv(self) -> BitVector:
+        raise NotImplementedError()
+
+    def __neg__(self): return self.fp_neg()
+    def __add__(self, other): return self.fp_add(other)
+    def __sub__(self, other): return self.fp_sub(other)
+    def __mul__(self, other): return self.fp_mul(other)
+    def __truediv__(self, other): return self.fp_div(other)
+    def __mod__(self, other): return self.fp_rem(other)
+
+    def __eq__(self, other): return self.fp_eq(other)
+    def __ne__(self, other): return ~(self.fp_eq(other))
+    def __ge__(self, other): return self.fp_geq(other)
+    def __gt__(self, other): return self.fp_gt(other)
+    def __le__(self, other): return self.fp_leq(other)
+    def __lt__(self, other): return self.fp_lt(other)
+

--- a/hwtypes/fp_vector_abc.py
+++ b/hwtypes/fp_vector_abc.py
@@ -1,0 +1,190 @@
+from abc import ABCMeta, abstractmethod
+import typing as tp
+import weakref
+import warnings
+from enum import Enum, auto
+
+from . import AbstractBitVectorMeta, AbstractBitVector, AbstractBit
+
+class RoundingMode(Enum):
+    RNE = auto() # roundTiesToEven
+    RNA = auto() # roundTiesToAway
+    RTP = auto() # roundTowardPositive
+    RTN = auto() # roundTowardNegative
+    RTZ = auto() # roundTowardZero
+
+class AbstractFPVectorMeta(ABCMeta):
+    # FPVectorType, (eb, mb, mode, ieee_compliance) :  FPVectorType[eb, mb, mode, ieee_compliance]
+    _class_cache = weakref.WeakValueDictionary()
+
+    # FPVectorType : UnsizedFPVectorType, (eb, mb, mode ,ieee_compliance)
+    _class_info  = weakref.WeakKeyDictionary()
+
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        info = None
+        for base in bases:
+            if getattr(base, 'is_bound', False):
+                if info is None:
+                    info = base.info
+                elif info != base.info:
+                    raise TypeError("Can't inherit from multiple FP types")
+        t = super().__new__(mcs, name, bases, namespace, **kwargs)
+        if info is None:
+            mcs._class_info[t] = t, info
+        else:
+            mcs._class_info[t] = None, info
+
+        return t
+
+    def __getitem__(cls, idx : tp.Tuple[int, int, RoundingMode, bool]):
+        mcs = type(cls)
+        try:
+            return mcs._class_cache[cls, idx]
+        except KeyError:
+            pass
+
+        if cls.is_bound:
+            raise TypeError(f'{cls} is already bound')
+
+        if len(idx) != 4 or tuple(map(type,idx)) != (int, int, RoundingMode, bool):
+            raise IndexError(f'Constructing a floating point type requires:\n'
+                    'exponent bits : int, mantisa bits : int, RoundingMode, ieee_compliance : bool')
+
+        eb, mb, mode, ieee_compliance = idx
+
+        if eb <= 0 or mb <= 0:
+            raise ValueError('exponents bits and mantisa bits must be greater than 0')
+
+
+        bases = [cls]
+        bases.extend(b[idx] for b in cls.__bases__ if isinstance(b, AbstractFPVectorMeta))
+        bases = tuple(bases)
+        class_name = f'{cls.__name__}[{eb},{mb},{mode},{ieee_compliance}]'
+        t = mcs(class_name, bases, {})
+        t.__module__ = cls.__module__
+        mcs._class_cache[cls, idx] = t
+        mcs._class_info[t] = cls, idx
+
+        return t
+
+    @property
+    def unbound_t(cls) -> 'AbstractBitVectorMeta':
+        t = type(cls)._class_info[cls][0]
+        if t is not None:
+            return t
+        else:
+            raise AttributeError('type {} has no unsized_t'.format(cls))
+
+    @property
+    def size(cls):
+        return 1 + cls.exponent_size + cls.mantissa_size
+
+    @property
+    def is_bound(cls):
+        return cls.info is not None
+
+    @property
+    def info(cls):
+        return type(cls)._class_info[cls][1]
+
+    @property
+    def exponent_size(cls):
+        return cls.info[0]
+
+    @property
+    def mantissa_size(cls):
+        return cls.info[1]
+
+    @property
+    def mode(cls) -> RoundingMode:
+        return cls.info[2]
+
+    @property
+    def ieee_compliance(cls) -> bool:
+        return cls.info[3]
+
+class AbstractFPVector(metaclass=AbstractFPVectorMeta):
+    @property
+    def size(self) -> int:
+        return  type(self).size
+
+    @abstractmethod
+    def fp_abs(self) -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_neg(self) -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_add(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_sub(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_mul(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_div(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_fma(self, coef : 'AbstractFPVector', offset : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_sqrt(self) -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_rem(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_round_to_integral(self) -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_min(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_max(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+
+    @abstractmethod
+    def fp_leq(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+
+    @abstractmethod
+    def fp_lt(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+
+    @abstractmethod
+    def fp_geq(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+
+    @abstractmethod
+    def fp_gt(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+
+    @abstractmethod
+    def fp_eq(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_normal(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_subnormal(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_zero(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_infinite(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_NaN(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_negative(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def fp_is_positive(self) -> AbstractBit: pass
+
+    @abstractmethod
+    def to_ubv(self, size : int) -> AbstractBitVector: pass
+
+    @abstractmethod
+    def to_sbv(self, size : int) -> AbstractBitVector: pass
+
+    @abstractmethod
+    def reinterpret_as_bv(self) -> AbstractBitVector: pass

--- a/hwtypes/fp_vector_abc.py
+++ b/hwtypes/fp_vector_abc.py
@@ -115,49 +115,49 @@ class AbstractFPVector(metaclass=AbstractFPVectorMeta):
     def fp_neg(self) -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_add(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_add(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_sub(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_sub(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_mul(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_mul(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_div(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_div(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_fma(self, coef : 'AbstractFPVector', offset : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_fma(self, coef: 'AbstractFPVector', offset: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
     def fp_sqrt(self) -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_rem(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_rem(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
     def fp_round_to_integral(self) -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_min(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_min(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_max(self, other : 'AbstractFPVector') -> 'AbstractFPVector': pass
+    def fp_max(self, other: 'AbstractFPVector') -> 'AbstractFPVector': pass
 
     @abstractmethod
-    def fp_leq(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+    def fp_leq(self, other: 'AbstractFPVector') ->  AbstractBit: pass
 
     @abstractmethod
-    def fp_lt(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+    def fp_lt(self, other: 'AbstractFPVector') ->  AbstractBit: pass
 
     @abstractmethod
-    def fp_geq(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+    def fp_geq(self, other: 'AbstractFPVector') ->  AbstractBit: pass
 
     @abstractmethod
-    def fp_gt(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+    def fp_gt(self, other: 'AbstractFPVector') ->  AbstractBit: pass
 
     @abstractmethod
-    def fp_eq(self, other : 'AbstractFPVector') ->  AbstractBit: pass
+    def fp_eq(self, other: 'AbstractFPVector') ->  AbstractBit: pass
 
     @abstractmethod
     def fp_is_normal(self) -> AbstractBit: pass
@@ -188,3 +188,7 @@ class AbstractFPVector(metaclass=AbstractFPVectorMeta):
 
     @abstractmethod
     def reinterpret_as_bv(self) -> AbstractBitVector: pass
+
+    @classmethod
+    @abstractmethod
+    def reinterpret_from_bv(self, value: AbstractBitVector) -> 'AbstractFPVector': pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-numpy
 pysmt

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=[
         "hwtypes",
     ],
-    install_requires=['numpy', 'pysmt', 'z3-solver'],
+    install_requires=['pysmt', 'z3-solver', 'gmpy2'],
     long_description=long_description,
     long_description_content_type="text/markdown"
     # python_requires='>=3.6'

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -1,0 +1,209 @@
+import pytest
+import operator
+
+import ctypes
+import random
+from hwtypes import FPVector, RoundingMode
+import math
+
+#A sort of reference vector to test against
+#Wraps either ctypes.c_float or ctypes.c_double
+def _c_type_vector(T):
+    class vector:
+        def __init__(self, value):
+            self._value = T(value)
+
+        def __repr__(self):
+            return f'{self.value}'
+
+        @property
+        def value(self) -> float:
+            return self._value.value
+
+        def fp_abs(self):
+            if self.value < 0:
+                return type(self)(-self.value)
+            else:
+                return type(self)(self.value)
+
+        def fp_neg(self):
+            return type(self)(-self.value)
+
+        def fp_add(self, other):
+            return type(self)(self.value + other.value)
+
+        def fp_sub(self, other):
+            return type(self)(self.value - other.value)
+
+        def fp_mul(self, other):
+            return type(self)(self.value * other.value)
+
+        def fp_div(self, other):
+            return type(self)(self.value / other.value)
+
+        def fp_fma(self, coef, offset):
+            raise NotImplementedError()
+
+        def fp_sqrt(self):
+            return type(self)(math.sqrt(self.value))
+
+        def fp_rem(self, other):
+            return type(self)(math.remainder(self.value))
+
+        def fp_round_to_integral(self):
+            return type(self)(math.round(self.value))
+
+        def fp_min(self, other):
+            return type(self)(min(self.value, other.value))
+
+        def fp_max(self, other):
+            return type(self)(max(self.value, other.value))
+
+        def fp_leq(self, other):
+            return self.value <= other.value
+
+        def fp_lt(self, other):
+            return self.value < other.value
+
+        def fp_geq(self, other):
+            return self.value >= other.value
+
+        def fp_gt(self, other):
+            return self.value > other.value
+
+        def fp_eq(self, other):
+            return self.value == other.value
+
+        def fp_is_normal(self):
+            raise NotImplementedError()
+
+        def fp_is_subnormal(self):
+            raise NotImplementedError()
+
+        def fp_is_zero(self):
+            return self.value == 0.0
+
+        def fp_is_infinite(self):
+            return math.isinf(self.value)
+
+        def fp_is_NaN(self):
+            return math.isnan(self.value)
+
+        def fp_is_negative(self):
+            return self.value < 0.0
+
+        def fp_is_positive(self):
+            return self.value > 0.0
+
+        def to_ubv(self, size : int):
+            raise NotImplementedError()
+
+        def to_sbv(self, size : int):
+            raise NotImplementedError()
+
+        def reinterpret_as_bv(self):
+            raise NotImplementedError()
+
+        def __neg__(self): return self.fp_neg()
+        def __abs__(self): return self.fp_abs()
+        def __add__(self, other): return self.fp_add(other)
+        def __sub__(self, other): return self.fp_sub(other)
+        def __mul__(self, other): return self.fp_mul(other)
+        def __truediv__(self, other): return self.fp_div(other)
+        def __mod__(self, other): return self.fp_rem(other)
+
+        def __eq__(self, other): return self.fp_eq(other)
+        def __ne__(self, other): return ~(self.fp_eq(other))
+        def __ge__(self, other): return self.fp_geq(other)
+        def __gt__(self, other): return self.fp_gt(other)
+        def __le__(self, other): return self.fp_leq(other)
+        def __lt__(self, other): return self.fp_lt(other)
+
+        def __float__(self):
+            return self.value
+
+    return vector
+
+NTESTS = 100
+
+@pytest.mark.parametrize("CT, FT", [
+    (_c_type_vector(ctypes.c_float), FPVector[8, 23, RoundingMode.RNE, True]),
+    (_c_type_vector(ctypes.c_double), FPVector[11, 52, RoundingMode.RNE, True]),])
+def test_epsilon(CT, FT):
+    cx, fx = CT(1), FT(1)
+    c2, f2 = CT(2), FT(2)
+    while not ((cx/c2).fp_is_zero() or (fx/f2).fp_is_zero()):
+        assert float(cx) == float(fx)
+        cx = cx/c2
+        fx = fx/f2
+
+    assert not cx.fp_is_zero()
+    assert not fx.fp_is_zero()
+    assert (cx/c2).fp_is_zero()
+    assert (fx/f2).fp_is_zero()
+
+@pytest.mark.parametrize("op", [operator.neg, operator.abs])
+@pytest.mark.parametrize("CT, FT", [
+    (_c_type_vector(ctypes.c_float), FPVector[8, 23, RoundingMode.RNE, True]),
+    (_c_type_vector(ctypes.c_double), FPVector[11, 52, RoundingMode.RNE, True]),])
+@pytest.mark.parametrize("mean, variance", [
+    (0, 2**-64),
+    (0, 2**-16),
+    (0, 2**-4),
+    (0, 1),
+    (0, 2**4),
+    (0, 2**16),
+    (0, 2**64),
+    ])
+def test_unary_op(op, CT, FT, mean, variance):
+    for _ in range(NTESTS):
+        x = random.normalvariate(mean, variance)
+        cx = CT(x)
+        fx = FT(x)
+        assert float(cx) == float(fx)
+        cr, fr = op(cx), op(fx)
+        assert float(cr) == float(fr)
+
+@pytest.mark.parametrize("op", [operator.add, operator.sub, operator.mul, operator.truediv])
+@pytest.mark.parametrize("CT, FT", [
+    (_c_type_vector(ctypes.c_float), FPVector[8, 23, RoundingMode.RNE, True]),
+    (_c_type_vector(ctypes.c_double), FPVector[11, 52, RoundingMode.RNE, True]),])
+@pytest.mark.parametrize("mean, variance", [
+    (0, 2**-64),
+    (0, 2**-16),
+    (0, 2**-4),
+    (0, 1),
+    (0, 2**4),
+    (0, 2**16),
+    (0, 2**64),
+    ])
+def test_bin_op(op, CT, FT, mean, variance):
+    for _ in range(NTESTS):
+        x = random.normalvariate(mean, variance)
+        y = random.normalvariate(mean, variance)
+        cx, cy = CT(x), CT(y)
+        fx, fy = FT(x), FT(y)
+        cr, fr = op(cx, cy), op(fx, fy)
+        assert float(cr) == float(fr)
+
+@pytest.mark.parametrize("op", [operator.eq, operator.ne, operator.lt, operator.le, operator.gt, operator.ge])
+@pytest.mark.parametrize("CT, FT", [
+    (_c_type_vector(ctypes.c_float), FPVector[8, 23, RoundingMode.RNE, True]),
+    (_c_type_vector(ctypes.c_double), FPVector[11, 52, RoundingMode.RNE, True]),])
+@pytest.mark.parametrize("mean, variance", [
+    (0, 2**-64),
+    (0, 2**-16),
+    (0, 2**-4),
+    (0, 1),
+    (0, 2**4),
+    (0, 2**16),
+    (0, 2**64),
+    ])
+def test_bool_op(op, CT, FT, mean, variance):
+    for _ in range(NTESTS):
+        x = random.normalvariate(mean, variance)
+        y = random.normalvariate(mean, variance)
+        cx, cy = CT(x), CT(y)
+        fx, fy = FT(x), FT(y)
+        cr, fr = op(cx, cy), op(fx, fy)
+        assert bool(cr) == bool(fr)


### PR DESCRIPTION
Not quite feature complete -- a few methods do not work for NaN / denormals -- however as lassen does not require these this should be good enough for now.

The changes to `AbstractBitVectorMeta` are an artifact of trying to use it for the metaclass of `FPVector`.  This however, turned out to not be possible for a number of reasons.  I did not revert these changes as they do not effect behavior and they make `AbstractBitVectorMeta` more extensible.  

Introduces dependency on `gmpy2` which has system dependencies `gmp`, `mpfr`, `mpc`.  Could potentially create a separate package `hwtypes[float]` so that `hwtypes` remains pure python. If we go down that route we probably should separate `hwtypes[smt]` as well. 