### PR TITLE
Add __int__ method for Bit

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -105,6 +105,9 @@ class Bit(AbstractBit):
     def __bool__(self) -> bool:
         return self._value
 
+    def __int__(self) -> int:
+        return int(self._value)
+
     def __repr__(self) -> str:
         return 'Bit({})'.format(self._value)
 


### PR DESCRIPTION
Because we can't support it in magma/smt, we leave it as a member of the concrete class, but not the ABC