### PR TITLE
Abc simple

### DIFF
--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -3,7 +3,7 @@ import typing as tp
 
 import weakref
 
-from types import MappingProxyType, resolve_bases
+from types import MappingProxyType
 from collections.abc import Mapping, MutableMapping
 from .util import TypedProperty
 
@@ -88,7 +88,7 @@ class BoundMeta(type):
             if '_fields_cb' in namespace:
                 bound_types  = namespace['_fields_cb'](bound_types)
             else:
-                for t in resolve_bases(bases):
+                for t in bases:
                     if hasattr(t, '_fields_cb'):
                         bound_types = t._fields_cb(bound_types)
 

--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -3,8 +3,9 @@ import typing as tp
 
 import weakref
 
-from types import MappingProxyType
+from types import MappingProxyType, resolve_bases
 from collections.abc import Mapping, MutableMapping
+from .util import TypedProperty
 
 __all__ = ['BoundMeta', 'TupleMeta', 'ProductMeta', 'SumMeta', 'EnumMeta']
 
@@ -54,9 +55,6 @@ def is_adt_type(t):
 class BoundMeta(type):
     # (UnboundType, (types...)) : BoundType
     _class_cache = weakref.WeakValueDictionary()
-    # BoundType : (types...)
-    # UnboundType : None
-    _class_info  = weakref.WeakKeyDictionary()
 
     def __call__(cls, *args, **kwargs):
         if not cls.is_bound:
@@ -73,8 +71,11 @@ class BoundMeta(type):
             return obj
         return super().__call__(*args, **kwargs)
 
-    def __new__(mcs, name, bases, namespace, **kwargs):
-        bound_types = None
+    def __new__(mcs, name, bases, namespace, fields=None, **kwargs):
+        if '_fields_' in namespace:
+            raise TypeError('class attribute _fields_ is reversed by the type machinery')
+
+        bound_types = fields
         for base in bases:
             if isinstance(base, BoundMeta) and base.is_bound:
                 if bound_types is None:
@@ -83,12 +84,16 @@ class BoundMeta(type):
                     raise TypeError("Can't inherit from multiple different bound_types")
 
 
-        t = super().__new__(mcs, name, bases, namespace, **kwargs)
         if bound_types is not None:
-            bound_types = t._fields_cb(bound_types)
+            if '_fields_cb' in namespace:
+                bound_types  = namespace['_fields_cb'](bound_types)
+            else:
+                for t in resolve_bases(bases):
+                    if hasattr(t, '_fields_cb'):
+                        bound_types = t._fields_cb(bound_types)
 
-        mcs._class_info[t] = bound_types
-
+        namespace['_fields_'] = bound_types
+        t = super().__new__(mcs, name, bases, namespace, **kwargs)
         return t
 
 
@@ -117,19 +122,18 @@ class BoundMeta(type):
         bases.extend(b[idx] for b in cls.__bases__ if isinstance(b, BoundMeta))
         bases = tuple(bases)
         class_name = '{}[{}]'.format(cls.__name__, ', '.join(map(lambda t : t.__name__, idx)))
-        t = type(cls)(class_name, bases, {})
+        t = type(cls)(class_name, bases, {}, fields=idx)
         t.__module__ = cls.__module__
         BoundMeta._class_cache[cls, idx] = t
-        BoundMeta._class_info[t] = idx
         return t
 
     @property
     def fields(cls):
-        return BoundMeta._class_info[cls]
+        return cls._fields_
 
     @property
     def is_bound(cls) -> bool:
-        return BoundMeta._class_info[cls] is not None
+        return cls.fields is not None
 
     def __repr__(cls):
         return f"{cls.__name__}"
@@ -153,9 +157,6 @@ class TupleMeta(BoundMeta):
             yield cls(*args)
 
 class ProductMeta(TupleMeta):
-    # ProductType : (FieldName : FieldType)
-    _field_table = weakref.WeakKeyDictionary()
-
     def __new__(mcs, name, bases, namespace, **kwargs):
         fields = {}
         ns = {}
@@ -182,6 +183,13 @@ class ProductMeta(TupleMeta):
 
     @classmethod
     def from_fields(mcs, fields, name, bases, ns, **kwargs):
+        # not strictly necesarry could iterative over class dict finding
+        # TypedProperty to reconstuct _field_table_ but that seems bad
+        if '_field_table_' in ns:
+            raise TypeError('class attribute _field_table_ is reversed by the type machinery')
+        else:
+            ns['_field_table_'] = dict()
+
         def _get_tuple_base(bases):
             for base in bases:
                 if not isinstance(base, ProductMeta) and isinstance(base, TupleMeta):
@@ -193,9 +201,32 @@ class ProductMeta(TupleMeta):
 
         base = _get_tuple_base(bases)[tuple(fields.values())]
         bases = *bases, base
-        #this is all realy gross but I don't know how to do this cleanly
 
-        #need to build t so I can call super()
+        #field_name -> tuple index
+        idx_table = dict((k, i) for i,k in enumerate(fields.keys()))
+
+        def _make_prop(field_type, idx):
+            @TypedProperty(field_type)
+            def prop(self):
+                return self[idx]
+
+            @prop.setter
+            def prop(self, value):
+                self[idx] = value
+
+            return prop
+
+        #add properties to namespace
+        #build properties
+        for field_name, field_type in fields.items():
+            assert field_name not in ns
+            idx = idx_table[field_name]
+            ns['_field_table_'][field_name] = field_type
+            ns[field_name] = _make_prop(field_type, idx)
+
+        #this is all realy gross but I don't know how to do this cleanly
+        #need to build t so I can call super() in new and init
+        #need to exec to get proper signatures
         t = super().__new__(mcs, name, bases, ns, **kwargs)
         gs = {name : t, 'ProductMeta' : ProductMeta}
         ls = {}
@@ -219,32 +250,10 @@ def __init__(self, {type_sig}):
         exec(__init__, gs, ls)
         t.__init__ = ls['__init__']
 
-        idx_table = dict((k, i) for i,k in enumerate(fields.keys()))
-
-        #build properties
-        for field_name in fields.keys():
-            prop = f'''
-@property
-def {field_name}(self):
-    return self[{idx_table[field_name]}]
-
-@{field_name}.setter
-def {field_name}(self, value):
-    self[{idx_table[field_name]}] = value
-'''
-            exec(prop, gs, ls)
-            setattr(t, field_name, ls[field_name])
 
         #Store the field indexs
-        mcs._field_table[t] = _key_map_dict(idx_table, t)
         return t
 
-    def __getattribute__(cls, name):
-        try:
-            return type(cls)._field_table[cls][name]
-        except KeyError:
-            pass
-        return super().__getattribute__(name)
 
     def __getitem__(cls, idx):
         if cls.is_bound:
@@ -261,7 +270,7 @@ def {field_name}(self, value):
 
     @property
     def field_dict(cls):
-        return MappingProxyType(type(cls)._field_table[cls])
+        return MappingProxyType(cls._field_table_)
 
 
 class SumMeta(BoundMeta):
@@ -281,14 +290,14 @@ class SumMeta(BoundMeta):
 
 
 class EnumMeta(BoundMeta):
-    # EnumType : (ElemName : Elem)
-    _elem_name_table = weakref.WeakKeyDictionary()
-
     class Auto:
         def __repr__(self):
             return 'Auto()'
 
     def __new__(mcs, cls_name, bases, namespace, **kwargs):
+        if '_field_table_' in namespace:
+            raise TypeError('class attribute _field_table_ is reversed by the type machinery')
+
         elems = {}
         ns = {}
 
@@ -300,21 +309,20 @@ class EnumMeta(BoundMeta):
             else:
                 raise TypeError(f'Enum value should be int not {type(v)}')
 
+        ns['_field_table_'] = name_table = dict()
         t = super().__new__(mcs, cls_name, bases, ns, **kwargs)
 
         if not elems:
             return t
-
-
-        mcs._elem_name_table[t] = name_table = {}
 
         for name, value in elems.items():
             elem = t.__new__(t)
             elem.__init__(value)
             setattr(elem, '_name_', name)
             name_table[name] = elem
+            setattr(t, name, elem)
 
-        super()._class_info[t] = tuple(name_table.values())
+        t._fields_ = tuple(name_table.values())
 
         return t
 
@@ -323,16 +331,9 @@ class EnumMeta(BoundMeta):
             raise TypeError('Enums cannot be constructed by value')
         return elem
 
-    def __getattribute__(cls, name):
-        try:
-            return type(cls)._elem_name_table[cls][name]
-        except KeyError:
-            pass
-        return super().__getattribute__(name)
-
     @property
     def field_dict(cls):
-        return MappingProxyType(type(cls)._elem_name_table[cls])
+        return MappingProxyType(cls._field_table_)
 
     def enumerate(cls):
         yield from cls.fields

--- a/hwtypes/fp_vector_abc.py
+++ b/hwtypes/fp_vector_abc.py
@@ -31,6 +31,14 @@ class AbstractFPVectorMeta(ABCMeta):
 
         namespace['_info_'] = info[0], binding
         t = super().__new__(mcs, name, bases, namespace, **kwargs)
+
+        if binding is None:
+            #class is unbound so t.unbound_t -> t
+            t._info_ = t, binding
+        elif info[0] is None:
+            #class inherited from bound type so there is no unbound_t
+            t._info_ = None, binding
+
         return t
 
     def __getitem__(cls, idx : tp.Tuple[int, int, RoundingMode, bool]):

--- a/hwtypes/util.py
+++ b/hwtypes/util.py
@@ -25,8 +25,12 @@ class TypedProperty:
             @A.foo.setter #works
 
         class D(B):
-            @B.foo.setter #error
-        '''
+            @B.foo.setter #error unless T has atrribute setter in which case
+                          #T.setter is called for the decorator as B.Foo -> T.
+                          #In generalTypedProperty objects must not be modified
+                          #outside of the class in which they are declared
+
+    '''
     def __init__(self, T):
         self.T = T
         self.final = False
@@ -78,22 +82,3 @@ class TypedProperty:
 
     def deleter(self, fdel):
         return type(self)(self.T)(self.fget, self.fset, fdel, self.__doc__)
-
-
-#class A:
-#    def __init__(self, a):
-#        self._a = a
-#
-#    @TypedProperty(int)
-#    def a(self):
-#        return self._a
-#
-##class B(A):
-##    @A.a.setter
-##    def a(self, a):
-##        self._a = a
-##
-#print(A.a)
-#a = A(1)
-##b = B(2)
-##b.a = 3

--- a/hwtypes/util.py
+++ b/hwtypes/util.py
@@ -1,0 +1,99 @@
+class TypedProperty:
+    '''
+    Behaves mostly like property except:
+        class A:
+            @property
+            def foo(self): ...
+
+            @foo.setter
+            def foo(self, value): ...
+
+        A.Foo -> <property object at 0x...>
+
+        class B:
+            @TypedProperty(T)
+            def foo(self): ...
+
+            @foo.setter
+            def foo(self, value): ...
+
+        B.Foo -> T
+        B().foo = T() #works
+        B().foo = A() # TypeError expected T not A
+
+        class C(A):
+            @A.foo.setter #works
+
+        class D(B):
+            @B.foo.setter #error
+        '''
+    def __init__(self, T):
+        self.T = T
+        self.final = False
+        self.fget = None
+        self.fset = None
+        self.fdel = None
+        self.__doc__ = None
+
+    def __call__(self, fget=None, fset=None, fdel=None, doc=None):
+        self.fget = fget
+        self.fset = fset
+        self.fdel = fdel
+        if doc is None and fget is not None:
+            doc = fget.__doc__
+        self.__doc__ = doc
+        return self
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            if self.final:
+                return self.T
+            else:
+                return self
+
+        if self.fget is None:
+            raise AttributeError("unreadable attribute")
+        return self.fget(obj)
+
+    def __set__(self, obj, value):
+        if self.fset is None:
+            raise AttributeError("can't set attribute")
+        elif not isinstance(value, self.T):
+            raise TypeError(f'Expected {self.T} not {type(value)}')
+        self.fset(obj, value)
+
+    def __delete__(self, obj):
+        if self.fdel is None:
+            raise AttributeError("can't delete attribute")
+        self.fdel(obj)
+
+    def __set_name__(self, cls, name):
+        self.final = True
+
+    def getter(self, fget):
+        return type(self)(self.T)(fget, self.fset, self.fdel, self.__doc__)
+
+    def setter(self, fset):
+        return type(self)(self.T)(self.fget, fset, self.fdel, self.__doc__)
+
+    def deleter(self, fdel):
+        return type(self)(self.T)(self.fget, self.fset, fdel, self.__doc__)
+
+
+#class A:
+#    def __init__(self, a):
+#        self._a = a
+#
+#    @TypedProperty(int)
+#    def a(self):
+#        return self._a
+#
+##class B(A):
+##    @A.a.setter
+##    def a(self, a):
+##        self._a = a
+##
+#print(A.a)
+#a = A(1)
+##b = B(2)
+##b.a = 3

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -2,113 +2,122 @@ import pytest
 from hwtypes.adt import Product, Sum, Enum, Tuple
 from hwtypes.modifiers import new
 
-class En(Enum):
+class En1(Enum):
     a = 0
     b = 1
 
+class En2(Enum):
+    c = 0
+    d = 1
+
 class Pr(Product):
-    x = En
-    y = En
+    x = En1
+    y = En2
 
-Su = Sum[En, Pr]
+Su = Sum[En1, Pr]
 
-Tu = Tuple[En, En]
+Tu = Tuple[En1, En2]
 
 def test_enum():
-    assert set(En.enumerate()) == {
-            En.a,
-            En.b,
+    assert set(En1.enumerate()) == {
+            En1.a,
+            En1.b,
     }
 
-    assert En.a.value == 0
-    assert En.a is En.a
+    assert En1.a.value == 0
+    assert En1.a is En1.a
 
-    assert issubclass(En, Enum)
-    assert isinstance(En.a, Enum)
-    assert isinstance(En.a, En)
+    assert issubclass(En1, Enum)
+    assert isinstance(En1.a, Enum)
+    assert isinstance(En1.a, En1)
 
 def test_tuple():
     assert set(Tu.enumerate()) == {
-            Tu(En.a, En.a),
-            Tu(En.a, En.b),
-            Tu(En.b, En.a),
-            Tu(En.b, En.b),
+            Tu(En1.a, En2.c),
+            Tu(En1.a, En2.d),
+            Tu(En1.b, En2.c),
+            Tu(En1.b, En2.d),
     }
 
-    assert Tu(En.a, En.a).value == (En.a, En.a)
+    assert Tu(En1.a, En2.c).value == (En1.a, En2.c)
 
     assert issubclass(Tu, Tuple)
-    assert isinstance(Tu(En.a, En.a), Tuple)
-    assert isinstance(Tu(En.a, En.a), Tu)
+    assert isinstance(Tu(En1.a, En2.c), Tuple)
+    assert isinstance(Tu(En1.a, En2.c), Tu)
 
-    t = Tu(En.a, En.b)
-    assert (t[0],t[1]) == (En.a,En.b)
-    t[0] = En.b
-    assert (t[0],t[1]) == (En.b,En.b)
+    t = Tu(En1.a, En2.c)
+    assert (t[0],t[1]) == (En1.a,En2.c)
+    t[0] = En1.b
+    assert (t[0],t[1]) == (En1.b,En2.c)
 
     with pytest.raises(TypeError):
-        Tu(En.a, 1)
+        Tu(En1.a, 1)
 
     with pytest.raises(TypeError):
         t[1] = 1
 
 def test_product():
     assert set(Pr.enumerate()) == {
-            Pr(En.a, En.a),
-            Pr(En.a, En.b),
-            Pr(En.b, En.a),
-            Pr(En.b, En.b),
+            Pr(En1.a, En2.c),
+            Pr(En1.a, En2.d),
+            Pr(En1.b, En2.c),
+            Pr(En1.b, En2.d),
     }
 
-    assert Pr(En.a, En.a).value == (En.a, En.a)
+    assert Pr(En1.a, En2.c).value == (En1.a, En2.c)
 
     assert issubclass(Pr, Product)
-    assert isinstance(Pr(En.a, En.a), Product)
-    assert isinstance(Pr(En.a, En.a), Pr)
+    assert isinstance(Pr(En1.a, En2.c), Product)
+    assert isinstance(Pr(En1.a, En2.c), Pr)
 
-    assert Pr(En.a, En.b) == Tu(En.a, En.b)
+    assert Pr(En1.a, En2.c) == Tu(En1.a, En2.c)
     assert issubclass(Pr, Tu)
     assert issubclass(Pr, Tuple)
-    assert isinstance(Pr(En.a, En.b), Tu)
+    assert isinstance(Pr(En1.a, En2.c), Tu)
 
-    assert Pr[0] == Pr.x == En
-    assert Pr[1] == Pr.y == En
+    assert Pr[0] == Pr.x == En1
+    assert Pr[1] == Pr.y == En2
 
-    assert Pr.field_dict == {'x' : En, 'y' : En }
-    assert Pr(En.b, En.a).value_dict == {'x' : En.b, 'y' : En.a}
+    p = Pr(En1.a, En2.c)
+    assert p[0] == p.x == En1.a
+    assert p[1] == p.y == En2.c
 
-    p = Pr(En.a, En.b)
-    assert p[0] == p.x == En.a
-    assert p[1] == p.y == En.b
-    p.x = En.b
-    assert p[0] == p.x == En.b
-    p[0] = En.a
-    assert p[0] == p.x == En.a
+    assert Pr.field_dict == {'x' : En1, 'y' : En2 }
+    assert Pr(En1.b, En2.c).value_dict == {'x' : En1.b, 'y' : En2.c}
+
+    p = Pr(En1.a, En2.c)
+    assert p[0] == p.x == En1.a
+    assert p[1] == p.y == En2.c
+    p.x = En1.b
+    assert p[0] == p.x == En1.b
+    p[0] = En1.a
+    assert p[0] == p.x == En1.a
 
     with pytest.raises(TypeError):
-        Pr(En.a, 1)
+        Pr(En1.a, En1.a)
 
     with pytest.raises(TypeError):
-        p[0] = 1
+        p[0] = En2.c
+
 
 def test_sum():
     assert set(Su.enumerate()) == {
-            Su(En.a),
-            Su(En.b),
-            Su(Pr(En.a, En.a)),
-            Su(Pr(En.a, En.b)),
-            Su(Pr(En.b, En.a)),
-            Su(Pr(En.b, En.b)),
+            Su(En1.a),
+            Su(En1.b),
+            Su(Pr(En1.a, En2.c)),
+            Su(Pr(En1.a, En2.d)),
+            Su(Pr(En1.b, En2.c)),
+            Su(Pr(En1.b, En2.d)),
     }
 
-    assert Su(En.a).value == En.a
+    assert Su(En1.a).value == En1.a
 
     assert issubclass(Su, Sum)
-    assert isinstance(Su(En.a), Su)
-    assert isinstance(Su(En.a), Sum)
+    assert isinstance(Su(En1.a), Su)
+    assert isinstance(Su(En1.a), Sum)
 
-    assert Su.field_dict == {'En' : En, 'Pr' : Pr}
-    assert Su(En.a).value_dict == {'En' : En.a, 'Pr' : None}
+    assert Su.field_dict == {'En1' : En1, 'Pr' : Pr}
+    assert Su(En1.a).value_dict == {'En1' : En1.a, 'Pr' : None}
 
     with pytest.raises(TypeError):
         Su(1)
@@ -118,15 +127,15 @@ def test_new():
     t = new(Tuple)
     s = new(Tuple)
     assert issubclass(t, Tuple)
-    assert issubclass(t[En], t)
-    assert issubclass(t[En], Tuple[En])
+    assert issubclass(t[En1], t)
+    assert issubclass(t[En1], Tuple[En1])
     assert t is not Tuple
     assert s is not t
 
-    t = new(Sum, (En, Pr))
+    t = new(Sum, (En1, Pr))
     assert t is not Su
-    assert Sum[En, Pr] is Su
+    assert Sum[En1, Pr] is Su
     assert t.__module__ == 'hwtypes.modifiers'
 
-    t = new(Sum, (En, Pr), module=__name__)
+    t = new(Sum, (En1, Pr), module=__name__)
     assert t.__module__ == __name__

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,49 @@
+import pytest
+
+from hwtypes.util import TypedProperty
+
+def test_typedproperty():
+    class A:
+        _x  : int
+        def __init__(self, x):
+            self.x = x
+
+        @TypedProperty(int)
+        def x(self):
+            return self._x
+
+        @x.setter
+        def x(self, val):
+            self._x = val
+
+        @TypedProperty(str)
+        def foo(self):
+            return 'foo'
+
+        @property
+        def bar(self):
+            return 'bar'
+
+    assert A.x is int
+    assert A.foo is str
+
+    a = A(0)
+
+    assert a.x == 0
+    a.x = 1
+    assert a.x == 1
+    assert a.foo == 'foo'
+
+    with pytest.raises(TypeError):
+        a.x = 'a'
+
+    with pytest.raises(AttributeError):
+        class B(A):
+            @A.foo.setter
+            def foo(self, value):
+                pass
+
+    class C(A):
+        @A.bar.setter
+        def bar(self, value):
+            pass


### PR DESCRIPTION
When building the FP library I ran into some annoyances in how I was binding types with getitem.  I had been using lookup tables in the metaclass to store information however, this meant the info was not available until after class construction was complete. To avoid this I reserved the name `_info_` and inserted the required information into the the namespace.

This pull requests does something similar for the other metaclasses.  This in many ways simplifies the metaclasses / classes as there are no more crazy redirects through weakref dictionaries. Instead information is stored in `_info_` for types constructed by `AbstractBitVectorMeta` and `_fields_` / `_field_table_` for those constructed by `BoundMeta`.

This should have no effect on user code unless it was using one of the reserved names.

Both peak and lassen pass travis with this branch:
https://travis-ci.org/phanrahan/peak/builds/538426697
https://travis-ci.com/StanfordAHA/lassen/builds/113493648