### PR TITLE
Remove deprecated constructors from BitVector

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -89,15 +89,7 @@ class Bit(AbstractBit):
             t_branch = fb_t(t_branch)
             T = fb_t
         else:
-            t_branch = BV_t(t_branch)
-            f_branch = BV_t(f_branch)
-            ext = t_branch.size - f_branch.size
-            if ext > 0:
-                f_branch = f_branch.zext(ext)
-            elif ext < 0:
-                t_branch = t_branch.zext(-ext)
-
-            T = type(t_branch)
+            raise TypeError(f'Atleast one branch must be a {self.get_family().BitVector}')
 
 
         return t_branch if self else f_branch

--- a/hwtypes/bit_vector_abc.py
+++ b/hwtypes/bit_vector_abc.py
@@ -22,7 +22,8 @@ class AbstractBitVectorMeta(ABCMeta):
             else:
                 return super().__call__(value, *args, **kwargs)
         else:
-            warnings.warn('DEPRECATION WARNING: Use of implicitly sized BitVectors is deprecated')
+            warnings.warn('DEPRECATION WARNING: Use of implicitly sized '
+                          'BitVectors is deprecated', DeprecationWarning)
 
             if value is _MISSING:
                 raise TypeError('Cannot construct {} without a value'.format(cls, value))

--- a/hwtypes/bit_vector_abc.py
+++ b/hwtypes/bit_vector_abc.py
@@ -15,17 +15,14 @@ class AbstractBitVectorMeta(ABCMeta):
     # BitVectorType, size :  BitVectorType[size]
     _class_cache = weakref.WeakValueDictionary()
 
-    def __call__(cls, value=_MISSING, size=_MISSING, *args, **kwargs):
-        if cls.is_sized and size is not _MISSING:
-            raise TypeError('Cannot use old style construction on sized types')
-        elif cls.is_sized:
+    def __call__(cls, value=_MISSING, *args, **kwargs):
+        if cls.is_sized:
             if value is _MISSING:
                 return super().__call__(*args, **kwargs)
             else:
                 return super().__call__(value, *args, **kwargs)
-        elif size is _MISSING or size is None:
-            if size is None:
-                warnings.warn('DEPRECATION WARNING: Use of BitVectorT(value, size) is deprecated')
+        else:
+            warnings.warn('DEPRECATION WARNING: Use of implicitly sized BitVectors is deprecated')
 
             if value is _MISSING:
                 raise TypeError('Cannot construct {} without a value'.format(cls, value))
@@ -41,8 +38,6 @@ class AbstractBitVectorMeta(ABCMeta):
                 size = max(int(value).bit_length(), 1)
             else:
                 raise TypeError('Cannot construct {} from {}'.format(cls, value))
-        else:
-            warnings.warn('DEPRECATION WARNING: Use of BitVectorT(value, size) is deprecated')
 
         return type(cls).__call__(cls[size], value)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/leonardt/hwtypes',
     author='Leonard Truong',
     author_email='lenny@cs.stanford.edu',
-    version='1.0.13',
+    version='1.1.0',
     description='Python implementations of fixed size hardware types (Bit, '
                 'BitVector, UInt, SInt, ...) based on the SMT-LIB2 semantics',
     scripts=[],

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -96,3 +96,14 @@ def test_setitem():
   assert repr(bv) == 'BitVector[3](6)'
   bv[2] = 0
   assert repr(bv) == 'BitVector[3](2)'
+
+@pytest.mark.parametrize("val", [
+        BitVector.random(8),
+        BitVector.random(8).as_sint(),
+        BitVector.random(8).as_uint(),
+        [0,1,1,0],
+    ])
+def test_deprecated(val):
+    with pytest.warns(DeprecationWarning):
+        BitVector(val)
+

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -88,7 +88,7 @@ def test_eq():
 
 
 def test_setitem():
-  bv = BitVector(5)
+  bv = BitVector[3](5)
   assert bv.as_uint() ==5
   bv[0] = 0
   assert repr(bv) == 'BitVector[3](4)'

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -67,10 +67,6 @@ def test_size():
     with pytest.raises(TypeError):
         C[6]
 
-    x = BV(5)
-    assert x.size == 3
-    assert type(x).size == 3
-
 def test_instance():
     x = BV[8](0)
     assert isinstance(x, ABV)

--- a/tests/test_optypes.py
+++ b/tests/test_optypes.py
@@ -80,19 +80,13 @@ def test_ite(t_constructor, t_size, f_constructor, f_size):
     if t_constructor is f_constructor is _rand_bv and t_size == f_size:
         res = pred.ite(t, f)
         assert type(res) is type(t)
-    elif t_constructor is f_constructor is _rand_bv:
+    elif t_constructor is f_constructor:
+        # either both ints or BV with different size
         with pytest.raises(TypeError):
             res = pred.ite(t, f)
-    elif t_constructor is f_constructor: #rand int
-        res = pred.ite(t, f)
-        t_size = max(t.bit_length(), 1)
-        f_size = max(f.bit_length(), 1)
-        assert type(res) is BitVector[max(t_size, f_size)]
     elif t_constructor is _rand_bv:
         res = pred.ite(t, f)
         assert type(res) is BitVector[t_size]
     else: #t_constructor is _rand_int
-        print(type(t), t, t_constructor, t_size)
-        print(type(f), f, f_constructor, f_size)
         res = pred.ite(t, f)
         assert type(res) is BitVector[f_size]


### PR DESCRIPTION
Also deprecates implicit size constructors. 