### PR TITLE
Make modifiers work with ADT types

### DIFF
--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -221,13 +221,6 @@ class ProductMeta(TupleMeta):
     def __new__(mcs, name, bases, namespace, cache=False, **kwargs):
         fields = {}
         ns = {}
-        for base in bases:
-            if base.is_bound:
-                for k,v in base.field_dict.items():
-                    if k in fields:
-                        raise TypeError(f'Conflicting definitions of field {k}')
-                    else:
-                        fields[k] = v
 
         for k, v in namespace.items():
             if k in RESERVED_SUNDERS:

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -4,6 +4,7 @@ from hwtypes import Bit, AbstractBit
 import hwtypes.modifiers as modifiers
 from hwtypes.modifiers import make_modifier, is_modified, is_modifier
 from hwtypes.modifiers import get_modifier, get_unmodified
+from hwtypes.adt import Tuple, Product, Sum
 
 modifiers._DEBUG = True
 
@@ -40,6 +41,28 @@ def test_basic():
 
     with pytest.raises(TypeError):
         get_unmodified(Bit)
+
+
+def test_modify_adt():
+    Mod = make_modifier("Mod")
+
+    T = Tuple[int, str]
+    MT = Mod(T)
+    assert issubclass(MT, T)
+
+    class P(Product):
+        x = int
+        y = str
+
+    MP = Mod(P)
+    assert issubclass(MP, T)
+    assert issubclass(MP, P)
+    assert issubclass(MP, MT)
+
+    S = Sum[int, str]
+    MS = Mod(S)
+    assert issubclass(MS, S)
+    assert MS(0).value == 0
 
 
 def test_cache():


### PR DESCRIPTION
Removed code no longer serve any purpose other than to break modifiers