### PR TITLE
Rebind fix

### DIFF
--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -179,12 +179,12 @@ class BoundMeta(type): #, metaclass=ABCMeta):
     def __repr__(cls):
         return f"{cls.__name__}"
 
-    def rebind(cls, A: type, B: type, rebind_sub_types: bool = False):
+    def rebind(cls, A: type, B: type, rebind_sub_types: bool = False, rebind_recursive: bool = True):
         new_fields = []
         for T in cls.fields:
             if T == A or (rebind_sub_types and _issubclass(T,A)):
                 new_fields.append(B)
-            elif isinstance(T, BoundMeta):
+            elif rebind_recursive and isinstance(T, BoundMeta):
                 new_fields.append(T.rebind(A, B, rebind_sub_types))
             else:
                 new_fields.append(T)
@@ -375,12 +375,12 @@ def __init__(self, {type_sig}):
         return cls._from_fields(fields, name, (cls,), ns, cache)
 
 
-    def rebind(cls, A: type, B: type, rebind_sub_types: bool = False):
+    def rebind(cls, A: type, B: type, rebind_sub_types: bool = False, rebind_recursive: bool = True):
         new_fields = OrderedDict()
         for field, T in cls.field_dict.items():
             if T == A or (rebind_sub_types and _issubclass(T,A)):
                 new_fields[field] = B
-            elif isinstance(T, BoundMeta):
+            elif rebind_recursive and isinstance(T, BoundMeta):
                 new_fields[field] = T.rebind(A, B, rebind_sub_types)
             else:
                 new_fields[field] = T
@@ -480,7 +480,7 @@ class EnumMeta(BoundMeta):
     def enumerate(cls):
         yield from cls.fields
 
-    def rebind(cls, A: type, B: type, rebind_sub_types: bool = False):
+    def rebind(cls, A: type, B: type, rebind_sub_types: bool = False, rebind_recursive: bool = True):
         # Enums aren't bound to types
         # could potentialy rebind values but that seems annoying
         return cls

--- a/hwtypes/adt_util.py
+++ b/hwtypes/adt_util.py
@@ -19,10 +19,14 @@ def rebind_bitvector(
         else:
             return bv_type_1
     elif isinstance(adt, BoundMeta):
-        new_adt = adt
+        _to_new = []
         for field in adt.fields:
             new_field = rebind_bitvector(field, bv_type_0, bv_type_1,keep_modifiers)
-            new_adt = new_adt.rebind(field, new_field)
+            _to_new.append((field,new_field))
+        new_adt = adt
+
+        for field,new_field in _to_new:
+            new_adt = new_adt.rebind(field, new_field, rebind_recursive=False)
         return new_adt
     else:
         return adt

--- a/tests/test_rebind.py
+++ b/tests/test_rebind.py
@@ -159,3 +159,17 @@ def test_rebind_mod():
     A_smt = rebind_keep_modifiers(A_smt, AbstractBit, SMTBit)
     assert A_smt.b == M(SMTBitVector[4])
     assert A_smt.a == M(SMTBit)
+
+#Tests an issue with rebind_bitvector and Sum
+#The issue:
+#   If we had Sum[A,B] and A was contained within B
+#   (like a field of a Tuple or Product), rebind would fail non-deterministically.
+def test_sum_issue():
+    for _ in range(1000):
+        BV = BitVector
+        SBV = SMTBitVector
+        T = Tuple[BV[8],BV[1]]
+        T_smt = rebind_bitvector(T,AbstractBitVector,SMTBitVector, True)
+        S = Sum[T,BV[8]]
+        S_smt = rebind_bitvector(S,AbstractBitVector,SMTBitVector, True)
+        assert T_smt in S_smt.fields


### PR DESCRIPTION
There was an issue with rebind that non-deterministically failed when you had something like the following:

T = Tuple[A,B]
S = Sum[T,A]

This PR is a fix for rebind_bitvector and a unit test for the issue.