### PR TITLE
Modifiers cannot be applied multiple times

### DIFF
--- a/hwtypes/modifiers.py
+++ b/hwtypes/modifiers.py
@@ -107,7 +107,7 @@ def make_modifier(name, cache=False):
         except KeyError:
             pass
 
-    ModType = _ModifierMeta(name, (AbstractModifier,), {})
+    ModType = _ModifierMeta(name, (AbstractModifier, ), {})
 
     if cache:
         return _mod_cache.setdefault(name, ModType)
@@ -125,6 +125,8 @@ def unwrap_modifier(T):
 
 def wrap_modifier(T, mods):
     wrapped = T
+    if len(set(mods)) != len(mods):
+        raise TypeError(f"{mods} must contain no duplicates")
     for mod in mods:
         wrapped = mod(wrapped)
     return wrapped

--- a/hwtypes/modifiers.py
+++ b/hwtypes/modifiers.py
@@ -107,7 +107,7 @@ def make_modifier(name, cache=False):
         except KeyError:
             pass
 
-    ModType = _ModifierMeta(name, (AbstractModifier, ), {})
+    ModType = _ModifierMeta(name, (AbstractModifier,), {})
 
     if cache:
         return _mod_cache.setdefault(name, ModType)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -85,5 +85,7 @@ def test_nested():
     ABCBit = C(B(A(Bit)))
     base, mods = unwrap_modifier(ABCBit)
     assert base is Bit
-    assert mods == [A,B,C]
-    assert wrap_modifier(Bit,mods) == ABCBit
+    assert mods == [A, B, C]
+    assert wrap_modifier(Bit, mods) == ABCBit
+    with pytest.raises(ValueError):
+        wrap_modifier(Bit, [A, B, C, A])

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -87,5 +87,5 @@ def test_nested():
     assert base is Bit
     assert mods == [A, B, C]
     assert wrap_modifier(Bit, mods) == ABCBit
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         wrap_modifier(Bit, [A, B, C, A])


### PR DESCRIPTION
Adds a check to wrap_modifiers to verify that two of the same modifiers are not applied.
This check is probably best done in _ModifierMeta.__call__ as currently it returns a cryptic error message