### PR TITLE
Added the following two helper functions for modifiers

### DIFF
--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -60,7 +60,7 @@ RESERVED_ATTRS = frozenset(RESERVED_NAMES | RESERVED_SUNDERS)
 
 class Syntax(type):
     def __subclasscheck__(cls, sub):
-        return super().__subclasscheck__(getattr(sub, '_syntax_', None))
+        return super().__subclasscheck__(getattr(sub, '_syntax_', type(None)))
 
     def __instancecheck__(cls, instance):
         return cls.__subclasscheck__(type(instance))

--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -1,6 +1,6 @@
+from abc import ABCMeta, abstractmethod
 import itertools as it
 import typing as tp
-from abc import ABCMeta, abstractmethod
 import weakref
 
 from types import MappingProxyType
@@ -53,15 +53,27 @@ RESERVED_SUNDERS = frozenset({
     '_fields_',
     '_field_table_',
     '_unbound_base_',
+    '_syntax_',
 })
 
 RESERVED_ATTRS = frozenset(RESERVED_NAMES | RESERVED_SUNDERS)
 
+class Syntax(type):
+    def __subclasscheck__(cls, sub):
+        return super().__subclasscheck__(getattr(sub, '_syntax_', None))
+
+    def __instancecheck__(cls, instance):
+        return cls.__subclasscheck__(type(instance))
+
+
+class AttrSyntax(metaclass=Syntax): pass
+class GetitemSyntax(metaclass=Syntax): pass
 
 # Can't have abstract metaclass https://bugs.python.org/issue36881
-class GetitemSyntax: #(metaclass=ABCMeta):
+class _GetitemSyntax(type): #(metaclass=ABCMeta):
     # Should probaly do more than it currently does but it gets the job done
     ORDERED = False
+    _syntax_ = GetitemSyntax
 
     def __getitem__(cls, idx):
         if not isinstance(idx, tp.Iterable):
@@ -78,10 +90,12 @@ class GetitemSyntax: #(metaclass=ABCMeta):
     def _from_idx(cls, idx):
         pass
 
-class AttrSyntax(type): #, metaclass=ABCMeta):
+
+class _AttrSyntax(type): #, metaclass=ABCMeta):
     # Tells AttrSyntax which attrs are fields
     FIELDS_T = type
     ORDERED =  False
+    _syntax_ = AttrSyntax
 
     def __new__(mcs, name, bases, namespace, cache=False, **kwargs):
         fields = {}
@@ -160,7 +174,8 @@ class AttrSyntax(type): #, metaclass=ABCMeta):
     def _from_fields(mcs, fields, name, bases, ns, **kwargs):
         pass
 
-class BoundMeta(GetitemSyntax, type): #, metaclass=ABCMeta):
+
+class BoundMeta(_GetitemSyntax): #, metaclass=ABCMeta):
     # for legacy reasons
     ORDERED = True
 
@@ -284,6 +299,7 @@ class BoundMeta(GetitemSyntax, type): #, metaclass=ABCMeta):
     def is_cached(cls):
         return getattr(cls, '_cached_', False)
 
+
 class TupleMeta(BoundMeta):
     ORDERED = True
 
@@ -309,7 +325,7 @@ class TupleMeta(BoundMeta):
         return MappingProxyType({idx : field for idx, field in enumerate(cls.fields)})
 
 
-class ProductMeta(AttrSyntax, TupleMeta):
+class ProductMeta(_AttrSyntax, TupleMeta):
     FIELDS_T = type
     ORDERED = True
 
@@ -437,7 +453,7 @@ class SumMeta(BoundMeta):
         return MappingProxyType({field : field for field in cls.fields})
 
 
-class TaggedUnionMeta(AttrSyntax, SumMeta):
+class TaggedUnionMeta(_AttrSyntax, SumMeta):
     FIELDS_T = type
     ORDERED = False
 
@@ -495,11 +511,10 @@ class TaggedUnionMeta(AttrSyntax, SumMeta):
                 yield cls(**{tag: field()})
 
 
-class EnumMeta(AttrSyntax, BoundMeta):
+class EnumMeta(_AttrSyntax, BoundMeta):
     class Auto:
         def __repr__(self):
             return 'Auto()'
-
 
     FIELDS_T = int, Auto
     ORDERED = False
@@ -514,23 +529,23 @@ class EnumMeta(AttrSyntax, BoundMeta):
                 else:
                     raise TypeError('Can only inherit from one enum type')
 
-        t = super().__new__(mcs, name, bases, ns, **kwargs)
+        cls = super().__new__(mcs, name, bases, ns, **kwargs)
 
         name_table = dict()
         for name, value in fields.items():
-            elem = t.__new__(t)
-            t.__init__(elem, value)
+            elem = cls.__new__(cls)
+            cls.__init__(elem, value)
             setattr(elem, '_name_', name)
             name_table[name] = elem
-            setattr(t, name, elem)
+            setattr(cls, name, elem)
 
-        t._fields_ = tuple(name_table.values())
-        t._field_table_ = name_table
+        cls._fields_ = tuple(name_table.values())
+        cls._field_table_ = name_table
 
         if enum_base is not None:
-            t._unbound_base_ = enum_base
+            cls._unbound_base_ = enum_base
 
-        return t
+        return cls
 
     def __call__(cls, elem):
         if not isinstance(elem, cls):

--- a/hwtypes/modifiers.py
+++ b/hwtypes/modifiers.py
@@ -138,11 +138,11 @@ def strip_modifiers(adt_t):
     #remove modifiers from this level
     adt_t, _ = unwrap_modifier(adt_t)
     if isinstance(adt_t, AttrSyntax) and not isinstance(adt_t, EnumMeta):
-        new_fields = [strip_modifiers(sub_adt_t) for sub_adt_t in adt_t.fields]
-        return adt_t.unbound_t[new_fields]
-    elif isinstance(adt_t, GetitemSyntax):
         new_fields = {n:strip_modifiers(sub_adt_t) for n, sub_adt_t in adt_t.field_dict.items()}
         return adt_t.unbound_t.from_fields(adt_t.__name__, new_fields)
+    elif isinstance(adt_t, GetitemSyntax):
+        new_fields = [strip_modifiers(sub_adt_t) for sub_adt_t in adt_t.fields]
+        return adt_t.unbound_t[new_fields]
     else:
         return adt_t
 
@@ -152,11 +152,11 @@ def push_modifiers(adt_t, mods=[]):
     adt_t, new_mods = unwrap_modifier(adt_t)
     mods = new_mods + mods
     if isinstance(adt_t, AttrSyntax) and not isinstance(adt_t, EnumMeta):
-        new_fields = [push_modifiers(sub_adt_t, mods) for sub_adt_t in adt_t.fields]
-        return adt_t.unbound_t[new_fields]
-    elif isinstance(adt_t, GetitemSyntax):
         new_fields = {n:push_modifiers(sub_adt_t, mods) for n, sub_adt_t in adt_t.field_dict.items()}
         return adt_t.unbound_t.from_fields(adt_t.__name__, new_fields)
+    elif isinstance(adt_t, GetitemSyntax):
+        new_fields = [push_modifiers(sub_adt_t, mods) for sub_adt_t in adt_t.fields]
+        return adt_t.unbound_t[new_fields]
     else:
         return wrap_modifier(adt_t, mods)
 

--- a/hwtypes/modifiers.py
+++ b/hwtypes/modifiers.py
@@ -1,7 +1,10 @@
 import types
 import weakref
+from .adt import Product, Sum, Enum, Tuple
+from .bit_vector_abc import AbstractBit, AbstractBitVector
 
-__ALL__ = ['new', 'make_modifier', 'is_modified', 'is_modifier', 'get_modifier', 'get_unmodified']
+
+__ALL__ = ['new', 'make_modifier', 'is_modified', 'is_modifier', 'get_modifier', 'get_unmodified', 'strip_modifiers', 'push_modifiers']
 
 
 _DEBUG = False
@@ -107,7 +110,7 @@ def make_modifier(name, cache=False):
         except KeyError:
             pass
 
-    ModType = _ModifierMeta(name, (AbstractModifier,), {})
+    ModType = _ModifierMeta(name, (AbstractModifier, ), {})
 
     if cache:
         return _mod_cache.setdefault(name, ModType)
@@ -128,3 +131,46 @@ def wrap_modifier(T, mods):
     for mod in mods:
         wrapped = mod(wrapped)
     return wrapped
+
+#Takes an ADT type and removes any modifiers on any level of the Tree
+def strip_modifiers(adt_t):
+    #remove modifiers from this level
+    adt_t, _ = unwrap_modifier(adt_t)
+    if (issubclass(adt_t, AbstractBit) or issubclass(adt_t, AbstractBitVector)):
+        return adt_t
+    elif issubclass(adt_t, Enum):
+        return adt_t
+    elif issubclass(adt_t, Sum):
+        new_fields = [strip_modifiers(sub_adt_t) for sub_adt_t in adt_t.fields]
+        return Sum[new_fields]
+    elif issubclass(adt_t, Product):
+        new_fields = {n:strip_modifiers(sub_adt_t) for n, sub_adt_t in adt_t.field_dict.items()}
+        return Product.from_fields(adt_t.__name__, new_fields)
+    elif issubclass(adt_t, Tuple):
+        new_fields = [strip_modifiers(sub_adt_t) for sub_adt_t in adt_t.fields]
+        return Tuple[new_fields]
+    else:
+        raise ValueError("Unreachable")
+
+#Takes an ADT type and pushes all the modifiers from internal nodes to leaf nodes
+def push_modifiers(adt_t, mods=[]):
+    #remove modifiers from this level
+    adt_t, new_mods = unwrap_modifier(adt_t)
+    mods = new_mods + mods
+    if (issubclass(adt_t, AbstractBit) or issubclass(adt_t, AbstractBitVector)):
+        return wrap_modifier(adt_t, mods)
+    elif issubclass(adt_t, Enum):
+        return wrap_modifier(adt_t, mods)
+    elif issubclass(adt_t, Sum):
+        new_fields = [push_modifiers(sub_adt_t, mods) for sub_adt_t in adt_t.fields]
+        return Sum[new_fields]
+    elif issubclass(adt_t, Product):
+        new_fields = {n:push_modifiers(sub_adt_t, mods) for n, sub_adt_t in adt_t.field_dict.items()}
+        return Product.from_fields(adt_t.__name__, new_fields)
+    elif issubclass(adt_t, Tuple):
+        new_fields = [push_modifiers(sub_adt_t, mods) for sub_adt_t in adt_t.fields]
+        return Tuple[new_fields]
+    else:
+        raise ValueError("Unreachable")
+
+

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -1,6 +1,6 @@
 import pytest
 from hwtypes.adt import Product, Sum, Enum, Tuple, TaggedUnion
-from hwtypes.adt_meta import RESERVED_ATTRS, ReservedNameError
+from hwtypes.adt_meta import RESERVED_ATTRS, ReservedNameError, AttrSyntax, GetitemSyntax
 from hwtypes.modifiers import new
 from hwtypes.adt_util import rebind_bitvector
 
@@ -386,3 +386,14 @@ def test_unbound_t(t, base):
 def test_deprecated(val):
     with pytest.warns(DeprecationWarning):
         val.value
+
+def test_adt_syntax():
+    # En1, Pr, Su, Tu, Ta
+    for T in (En1, Pr, Ta):
+        assert isinstance(T, AttrSyntax)
+        assert not isinstance(T, GetitemSyntax)
+
+    for T in (Su, Tu):
+        assert not isinstance(T, AttrSyntax)
+        assert isinstance(T, GetitemSyntax)
+

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -3,6 +3,8 @@ from hwtypes.adt import Product, Sum, Enum, Tuple, TaggedUnion
 from hwtypes.adt_meta import RESERVED_ATTRS, ReservedNameError, AttrSyntax, GetitemSyntax
 from hwtypes.modifiers import new
 from hwtypes.adt_util import rebind_bitvector
+from hwtypes import BitVector, AbstractBitVector, Bit, AbstractBit
+
 
 class En1(Enum):
     a = 0
@@ -396,4 +398,8 @@ def test_adt_syntax():
     for T in (Su, Tu):
         assert not isinstance(T, AttrSyntax)
         assert isinstance(T, GetitemSyntax)
+
+    for T in (str, Bit, BitVector[4], AbstractBit, AbstractBitVector[4], int):
+        assert not isinstance(T, AttrSyntax)
+        assert not isinstance(T, GetitemSyntax)
 


### PR DESCRIPTION
strip_modifiers removes all type modifiers within an ADT type
push_modifiers pushes all the type modifiers to the leafs of the ADT

automapper in peak will be using these, but they seemed generic/useful enough to add as helpers in hwtypes