### PR TITLE
Make polymorhic bitvector

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -82,30 +82,24 @@ class Bit(AbstractBit):
     def ite(self, t_branch, f_branch):
         '''
         typing works as follows:
-        given cls is type(self)
-        and BV is cls.get_family().BitVector
+            if t_branch and f_branch are both Bit[Vector] types
+            from the same family, and type(t_branch) is type(f_branch),
+            then return type is t_branch.
 
-        if both branches are subclasses of cls and one is a subclass of the
-        other return type is the parent type
+            elif t_branch and f_branch are both Bit[Vector] types
+            from the same family, then return type is a polymorphic
+            type.
 
-        if both branches are subclasses of BV and one is a subclass of the
-        other return type is the parent type
+            elif t_brand and f_branch are tuples of the
+            same length, then these rules are applied recursively
 
-        if one branch is a subclass of cls try to cast the other branch to that
-        type and return that type
+            else there is an error
 
-        if one branch is a subclass of BV try to cast the other branch to that
-        type and return that type
-
-        if both branches are tuples of the same length, then these tests are
-        applied recursively to each pair of elements
-
-        all other cases are errors
         '''
-        def _ite(t_branch, f_branch):
-            return t_branch if self else f_branch
+        def _ite(select, t_branch, f_branch):
+            return t_branch if select else f_branch
 
-        return build_ite(_ite, type(self), t_branch, f_branch)
+        return build_ite(_ite, self, t_branch, f_branch)
 
     def __bool__(self) -> bool:
         return self._value
@@ -114,7 +108,7 @@ class Bit(AbstractBit):
         return int(self._value)
 
     def __repr__(self) -> str:
-        return 'Bit({})'.format(self._value)
+        return f'{type(self).__name__}({self._value})'
 
     def __hash__(self) -> int:
         return hash(self._value)
@@ -178,7 +172,7 @@ class BitVector(AbstractBitVector):
         return str(int(self))
 
     def __repr__(self):
-        return "BitVector[{size}]({value})".format(value=self._value, size=self.size)
+        return f'{type(self).__name__}({self._value})'
 
     @property
     def value(self):
@@ -476,10 +470,8 @@ class BitVector(AbstractBitVector):
             return self.bvult(other)
         except InconsistentSizeError as e:
             raise e from None
-        except TypeError:
+        except TypeError as e:
             return NotImplemented
-
-
 
     def as_uint(self):
         return self._value
@@ -541,28 +533,20 @@ class BitVector(AbstractBitVector):
         return BitVector[width](random.randint(0, (1 << width) - 1))
 
 
-
-
 class NumVector(BitVector):
     __hash__ = BitVector.__hash__
 
+
 class UIntVector(NumVector):
     __hash__ = NumVector.__hash__
-
-    def __repr__(self):
-        return "UIntVector[{size}]({value})".format(value=self._value, size=self.size)
 
     @staticmethod
     def random(width):
         return UIntVector[width](random.randint(0, (1 << width) - 1))
 
 
-
 class SIntVector(NumVector):
     __hash__ = NumVector.__hash__
-
-    def __repr__(self):
-        return "SIntVector[{size}]({value})".format(value=self._value, size=self.size)
 
     def __int__(self):
         return self.as_sint()

--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -518,7 +518,7 @@ class BitVector(AbstractBitVector):
         return self.concat(T[1](self[-1]).repeat(ext))
 
     def ext(self, ext):
-        return self.zext(other)
+        return self.zext(ext)
 
     def zext(self, ext):
         ext = int(ext)

--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -612,7 +612,6 @@ class SIntVector(NumVector):
         w = width - 1
         return SIntVector[width](random.randint(-(1 << w), (1 << w) - 1))
 
-    @bv_cast
     def ext(self, other):
         return self.sext(other)
 

--- a/hwtypes/bit_vector_abc.py
+++ b/hwtypes/bit_vector_abc.py
@@ -16,7 +16,7 @@ class InconsistentSizeError(TypeError): pass
 #I want to be able differentiate an old style call
 #BitVector(val, None) from BitVector(val)
 _MISSING = object()
-class AbstractBitVectorMeta(ABCMeta):
+class AbstractBitVectorMeta(type): #:(ABCMeta):
     # BitVectorType, size :  BitVectorType[size]
     _class_cache = weakref.WeakValueDictionary()
 
@@ -319,5 +319,6 @@ class AbstractBitVector(metaclass=AbstractBitVectorMeta):
     def zext(self, other) -> 'AbstractBitVector':
         pass
 
+BitVectorMeta = AbstractBitVectorMeta
 
 _Family_ = TypeFamily(AbstractBit, AbstractBitVector, None, None)

--- a/hwtypes/bit_vector_util.py
+++ b/hwtypes/bit_vector_util.py
@@ -31,7 +31,9 @@ class PolyType(type):
             raise TypeError('Cannot construct PolyTypes across families')
 
 
-        bases = *cls._get_bases(T0, T1), PolyBase
+        # stupid generator to make sure PolyBase is not replicated
+        # and always comes last
+        bases = *(b for b in cls._get_bases(T0, T1) if b is not PolyBase), PolyBase
         class_name = f'{cls.__name__}[{T0.__name__}, {T1.__name__}, {select}]'
         meta, namespace, _ = types.prepare_class(class_name, bases)
 

--- a/hwtypes/smt_bit_vector.py
+++ b/hwtypes/smt_bit_vector.py
@@ -593,7 +593,7 @@ class SMTBitVector(AbstractBitVector):
             return self.bvult(other)
         except InconsistentSizeError as e:
             raise e from None
-        except TypeError:
+        except TypeError as e:
             return NotImplemented
 
 
@@ -692,7 +692,7 @@ class SMTSIntVector(SMTNumVector):
             return self.bvslt(other)
         except InconsistentSizeError as e:
             raise e from None
-        except TypeError:
+        except TypeError as e:
             return NotImplemented
 
     def __le__(self, other):
@@ -703,6 +703,8 @@ class SMTSIntVector(SMTNumVector):
         except TypeError:
             return NotImplemented
 
+    def ext(self, other):
+        return self.sext(other)
 
 
 

--- a/hwtypes/smt_bit_vector.py
+++ b/hwtypes/smt_bit_vector.py
@@ -135,33 +135,11 @@ class SMTBit(AbstractBit):
         return type(self)(smt.Xor(self.value, other.value))
 
     def ite(self, t_branch, f_branch):
-        '''
-        typing works as follows:
-        given cls is type(self)
-        and BV is cls.get_family().BitVector
-
-        if both branches are subclasses of cls and one is a subclass of the
-        other return type is the parent type
-
-        if both branches are subclasses of BV and one is a subclass of the
-        other return type is the parent type
-
-        if one branch is a subclass of cls try to cast the other branch to that
-        type and return that type
-
-        if one branch is a subclass of BV try to cast the other branch to that
-        type and return that type
-
-        if both branches are tuples of the same length, then these tests are
-        applied recursively to each pair of elements
-
-        all other cases are errors
-        '''
-        def _ite(t_branch, f_branch):
-            return smt.Ite(self.value, t_branch.value, f_branch.value)
+        def _ite(select, t_branch, f_branch):
+            return smt.Ite(select.value, t_branch.value, f_branch.value)
 
 
-        return build_ite(_ite, type(self), t_branch, f_branch, True, True)
+        return build_ite(_ite, self, t_branch, f_branch)
 
     def substitute(self, *subs : tp.List[tp.Tuple['SMTBit', 'SMTBit']]):
         return SMTBit(

--- a/hwtypes/smt_bit_vector.py
+++ b/hwtypes/smt_bit_vector.py
@@ -643,7 +643,6 @@ class SMTBitVector(AbstractBitVector):
 class SMTNumVector(SMTBitVector):
     pass
 
-
 class SMTUIntVector(SMTNumVector):
     pass
 

--- a/tests/test_optypes.py
+++ b/tests/test_optypes.py
@@ -3,11 +3,16 @@ import operator
 import random
 from itertools import product
 
-from hwtypes import BitVector, Bit
+from hwtypes import SIntVector, BitVector, Bit
 from hwtypes.bit_vector_abc import InconsistentSizeError
+from hwtypes.bit_vector_util import PolyVector
 
 def _rand_bv(width):
     return BitVector[width](random.randint(0, (1 << width) - 1))
+
+def _rand_signed(width):
+    return SIntVector[width](random.randint(0, (1 << width) - 1))
+
 
 def _rand_int(width):
     return random.randint(0, (1 << width) - 1)
@@ -69,29 +74,36 @@ def test_comp(op, width1, width2, use_int):
             assert type(res) is Bit
 
 
-@pytest.mark.parametrize("t_constructor", (_rand_bv, _rand_int))
-@pytest.mark.parametrize("t_size", (1, 2, 4, 8))
-@pytest.mark.parametrize("f_constructor", (_rand_bv, _rand_int))
-@pytest.mark.parametrize("f_size", (1, 2, 4, 8))
+@pytest.mark.parametrize("t_constructor", (_rand_bv, _rand_signed, _rand_int))
+@pytest.mark.parametrize("t_size", (1, 2, 4))
+@pytest.mark.parametrize("f_constructor", (_rand_bv, _rand_signed, _rand_int))
+@pytest.mark.parametrize("f_size", (1, 2, 4))
 def test_ite(t_constructor, t_size, f_constructor, f_size):
     pred =  Bit(_rand_int(1))
     t = t_constructor(t_size)
     f = f_constructor(f_size)
 
-    if t_constructor is f_constructor is _rand_bv and t_size == f_size:
+    t_is_bv_constructor = t_constructor in {_rand_signed, _rand_bv}
+    f_is_bv_constructor = f_constructor in {_rand_signed, _rand_bv}
+    sizes_equal = t_size == f_size
+
+    if (t_constructor is f_constructor and t_is_bv_constructor and sizes_equal):
+        # The same bv_constructor
         res = pred.ite(t, f)
         assert type(res) is type(t)
-    elif t_constructor is f_constructor is _rand_bv:
+    elif t_is_bv_constructor and f_is_bv_constructor and sizes_equal:
+        # Different bv_constuctor
+        res = pred.ite(t, f)
+        assert type(res) is PolyVector[type(t), type(f), pred]
+        # The bases should be the most specific types that are common
+        # to both branches. As SIntVect[size] is a subclass of
+        # BitVector[size], BitVector[size] is such a type.
+        assert type(res).__bases__ == (BitVector[t_size],)
+    elif t_is_bv_constructor and f_is_bv_constructor and not sizes_equal:
         # BV with different size
         with pytest.raises(InconsistentSizeError):
             res = pred.ite(t, f)
-    elif t_constructor is f_constructor:
-        # both int
+    else:
+        # Trying to coerce an int
         with pytest.raises(TypeError):
             res = pred.ite(t, f)
-    elif t_constructor is _rand_bv:
-        res = pred.ite(t, f)
-        assert type(res) is BitVector[t_size]
-    else: #t_constructor is _rand_int
-        res = pred.ite(t, f)
-        assert type(res) is BitVector[f_size]

--- a/tests/test_optypes.py
+++ b/tests/test_optypes.py
@@ -94,11 +94,10 @@ def test_ite(t_constructor, t_size, f_constructor, f_size):
     elif t_is_bv_constructor and f_is_bv_constructor and sizes_equal:
         # Different bv_constuctor
         res = pred.ite(t, f)
-        assert type(res) is PolyVector[type(t), type(f)]
         # The bases should be the most specific types that are common
-        # to both branches and PolyBase. As SIntVect[size] is a subclass of
-        # BitVector[size], BitVector[size] is such a type.
-        assert type(res).__bases__ == (BitVector[t_size], PolyBase)
+        # to both branches and PolyBase.
+        assert isinstance(res, PolyBase)
+        assert isinstance(res, BitVector[t_size])
     elif t_is_bv_constructor and f_is_bv_constructor and not sizes_equal:
         # BV with different size
         with pytest.raises(InconsistentSizeError):

--- a/tests/test_optypes.py
+++ b/tests/test_optypes.py
@@ -5,7 +5,7 @@ from itertools import product
 
 from hwtypes import SIntVector, BitVector, Bit
 from hwtypes.bit_vector_abc import InconsistentSizeError
-from hwtypes.bit_vector_util import PolyVector
+from hwtypes.bit_vector_util import PolyVector, PolyBase
 
 def _rand_bv(width):
     return BitVector[width](random.randint(0, (1 << width) - 1))
@@ -94,11 +94,11 @@ def test_ite(t_constructor, t_size, f_constructor, f_size):
     elif t_is_bv_constructor and f_is_bv_constructor and sizes_equal:
         # Different bv_constuctor
         res = pred.ite(t, f)
-        assert type(res) is PolyVector[type(t), type(f), pred]
+        assert type(res) is PolyVector[type(t), type(f)]
         # The bases should be the most specific types that are common
-        # to both branches. As SIntVect[size] is a subclass of
+        # to both branches and PolyBase. As SIntVect[size] is a subclass of
         # BitVector[size], BitVector[size] is such a type.
-        assert type(res).__bases__ == (BitVector[t_size],)
+        assert type(res).__bases__ == (BitVector[t_size], PolyBase)
     elif t_is_bv_constructor and f_is_bv_constructor and not sizes_equal:
         # BV with different size
         with pytest.raises(InconsistentSizeError):

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -1,0 +1,92 @@
+import pytest
+
+from pysmt import shortcuts as sc
+
+from hwtypes import BitVector, SIntVector, UIntVector
+from hwtypes import Bit
+
+from hwtypes import SMTBit, SMTBitVector
+from hwtypes import SMTUIntVector, SMTSIntVector
+
+@pytest.mark.parametrize("cond_0", [Bit(0), Bit(1)])
+@pytest.mark.parametrize("cond_1", [Bit(0), Bit(1)])
+def test_poly_bv(cond_0, cond_1):
+    S = SIntVector[8]
+    U = UIntVector[8]
+    val = cond_0.ite(S(0), U(0)) - 1
+
+    assert val < 0 if cond_0 else val > 0
+    val2 = cond_1.ite(S(-1), val)
+    val2 = val2.ext(1)
+    assert val2 == val.sext(1) if cond_0 or cond_1 else val2 == val.zext(1)
+
+    val3 = cond_1.ite(cond_0.ite(U(0), S(1)), cond_0.ite(S(-1), U(2)))
+
+    if cond_1:
+        if cond_0:
+            assert val3 == 0
+            assert val3 - 1 > 0
+        else:
+            assert val3 == 1
+            assert val3 - 2 < 0
+    else:
+        if cond_0:
+            assert val3 == -1
+            assert val3 < 0
+        else:
+            assert val3 == 2
+            assert val3 - 3 > 0
+
+def test_poly_smt():
+    S = SMTSIntVector[8]
+    U = SMTUIntVector[8]
+
+    c1 = SMTBit(name='c1')
+    u1 = U(name='u1')
+    u2 = U(name='u2')
+    s1 = S(name='s1')
+    s2 = S(name='s2')
+
+    # NOTE: __eq__ on pysmt terms is strict structural equivalence
+    # for example:
+    assert u1.value == u1.value  # .value extract pysmt term
+    assert u1.value != u2.value
+    assert (u1 * 2).value != (u1 + u1).value
+    assert (u1 + u2).value == (u1 + u2).value
+    assert (u1 + u2).value != (u2 + u1).value
+
+    # On to the real test
+    expr = c1.ite(u1, s1) < 1
+    # get the pysmt values
+    _c1, _u1, _s1 = c1.value, u1.value, s1.value
+    e1 = sc.Ite(_c1, _u1, _s1)
+    one = sc.BV(1, 8)
+    # Here we see that `< 1` dispatches symbolically
+    f = sc.Ite(_c1, sc.BVULT(e1, one), sc.BVSLT(e1, one))
+    assert expr.value == f
+
+    expr = expr.ite(c1.ite(u1, s1), c1.ite(s2, u2)).ext(1)
+
+    e2 = sc.Ite(_c1, s2.value, u2.value)
+    e3 = sc.Ite(f, e1, e2)
+
+    se = sc.BVSExt(e3, 1)
+    ze = sc.BVZExt(e3, 1)
+
+
+    g = sc.Ite(
+        f,
+        sc.Ite(_c1, ze, se),
+        sc.Ite(_c1, se, ze)
+     )
+    # Here we see that ext dispatches symbolically / recursively
+    assert expr.value == g
+
+
+    # Here we see that polymorphic types only build muxes if they need to
+    expr = c1.ite(u1, s1) + 1
+    assert expr.value == sc.BVAdd(e1, one)
+    # Note how it is not:
+    assert expr.value != sc.Ite(_c1, sc.BVAdd(e1, one), sc.BVAdd(e1, one))
+    # which was the pattern for sign dependent operators
+


### PR DESCRIPTION
Addresses #122 

Adds polymorphic types which allows "run-time polymorphism" 

Enables the following:
```Python
val = BitVector[size](...)
cond = Bit(...) # may be symbolic
s_val = SIntVector[size](val)
u_val = UIntVector[size](val)
c_val = cond.ite(s_val, u_val)
res = c_val < 1
```
where the final statement is effectively transformed to following by the type system
```Python
m0 = type(s_val).__lt__
m1 = type(u_val).__lt__ 
if m0 is m1:
    res = m0(c_val, 1) # doesn't matter which is called
else:
    res = cond.ite(m0(c_val, 1), m1(c_val, 1))
```


