### PR TITLE
Make cache=true default

### DIFF
--- a/hwtypes/adt_meta.py
+++ b/hwtypes/adt_meta.py
@@ -118,7 +118,7 @@ class _AttrSyntax(type): #, metaclass=ABCMeta):
     ORDERED =  False
     _syntax_ = AttrSyntax
 
-    def __new__(mcs, name, bases, namespace, cache=False, **kwargs):
+    def __new__(mcs, name, bases, namespace, cache=True, **kwargs):
         fields = {}
         ns = {}
 
@@ -253,8 +253,6 @@ class BoundMeta(_GetitemSyntax): #, metaclass=ABCMeta):
 
         return t
 
-
-
     def _from_idx(cls, idx) -> 'BoundMeta':
         mcs= type(cls)
         if cls.is_bound:
@@ -357,6 +355,7 @@ class TupleMeta(BoundMeta):
     @property
     def field_dict(cls):
         return MappingProxyType({idx : field for idx, field in enumerate(cls.fields)})
+
 
 class AnonymousProductMeta(TupleMeta):
     def _get_idx(cls, idx):

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -373,10 +373,29 @@ def test_tagged_union_from_fields():
 
 
 def test_tagged_union_caching():
-    assert Ta != Ta2
-    assert Ta != Ta3
+    global Ta
+    assert Ta is not Ta2
+    assert Ta is not Ta3
     assert Ta is TaggedUnion.from_fields('Ta', Ta3.field_dict, cache=True)
+    assert Ta2 is not TaggedUnion.from_fields('Ta2', Ta2.field_dict, cache=True)
+    assert Ta2 is not TaggedUnion.from_fields('Ta2', Ta2.field_dict, cache=False)
     assert Ta.field_dict == Ta2.field_dict == Ta3.field_dict
+
+    Ta_ = Ta
+
+    class Ta(TaggedUnion):
+        x = En1
+        y = En1
+        z = Pr
+
+    assert Ta_ is Ta
+
+    class Ta(TaggedUnion):
+        y = En1
+        x = En1
+        z = Pr
+
+    assert Ta_ is Ta
 
 
 def test_new():

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -19,12 +19,12 @@ Tu = Tuple[En1, En2]
 
 Ap = AnonymousProduct[{'x': En1, 'y': En2}]
 
-class Pr(Product, cache=True):
+class Pr(Product):
     x = En1
     y = En2
 
 
-class Pr2(Product):
+class Pr2(Product, cache=False):
     x = En1
     y = En2
 
@@ -36,12 +36,12 @@ class Pr3(Product, cache=True):
 
 Su = Sum[En1, Pr]
 
-class Ta(TaggedUnion, cache=True):
+class Ta(TaggedUnion):
     x = En1
     y = En1
     z = Pr
 
-class Ta2(TaggedUnion):
+class Ta2(TaggedUnion, cache=False):
     x = En1
     y = En1
     z = Pr
@@ -206,11 +206,20 @@ def test_product_from_fields():
 
 
 def test_product_caching():
-    assert Pr != Pr2
-    assert Pr != Pr3
+    global Pr
+    assert Pr is not Pr2
+    assert Pr is not Pr3
     assert Pr is Product.from_fields('Pr', {'x' : En1, 'y' : En2 }, cache=True)
     assert Pr.field_dict == Pr2.field_dict
     assert Pr.field_dict != Pr3.field_dict
+    Pr_ = Pr
+
+    class Pr(Product):
+        x = En1
+        y = En2
+
+    assert Pr_ is Pr
+
 
 
 def test_sum():


### PR DESCRIPTION
@rdaly525 Has requested `cache=True` be the default for `Product` and `TaggedUnion`.  I had previously made `cache=False` for these types because there is some strangeness around how to handle methods.   However as the ability to define methods on `AttrSyntax` is entirely unused I don't see the problem moving to `cache=True`.

Im not sure if this has any downstream effects on magma.