### PR TITLE
Add logic/test for srem by 0

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -340,6 +340,8 @@ class BitVector(AbstractBitVector):
     @bv_cast
     def bvsrem(self, other):
         other = other.as_sint()
+        if other == 0:
+            return self
         return type(self)(self.as_sint() % other)
 
     # bvsmod

--- a/tests/test_bv.py
+++ b/tests/test_bv.py
@@ -118,3 +118,12 @@ def test_old_style(val):
         with pytest.raises(TypeError):
             BitVector(val, 4)
 
+
+@pytest.mark.parametrize("op, reference", [
+    (operator.floordiv, lambda x, y: x // y if y != 0 else -1),
+    (operator.mod,      lambda x, y: x % y if y != 0 else x),
+])
+def test_operator_by_0(op, reference):
+    I0, I1 = BitVector.random(5), 0
+    expected = unsigned(reference(int(I0), int(I1)), 5)
+    assert expected == int(op(I0, I1))

--- a/tests/test_sint.py
+++ b/tests/test_sint.py
@@ -71,3 +71,13 @@ def test_signed():
     a = SIntVector[4](-4)
     assert a._value != 4, "Stored as unsigned two's complement value"
     assert int(a) == -4, "int returns the native signed int representation"
+
+
+@pytest.mark.parametrize("op, reference", [
+    (operator.floordiv, lambda x, y: x // y if y != 0 else -1),
+    (operator.mod,      lambda x, y: x % y if y != 0 else x),
+])
+def test_operator_by_0(op, reference):
+    I0, I1 = SIntVector.random(5), 0
+    expected = signed(reference(int(I0), int(I1)), 5)
+    assert expected == int(op(I0, I1))


### PR DESCRIPTION
Noticed a ZeroDivisionError from bvsrem

```
      def test_operator_by_0(op, reference):
          I0, I1 = SIntVector.random(5), 0
          expected = signed(reference(int(I0), int(I1)), 5)
  >       assert expected == int(op(I0, I1))

  tests/test_sint.py:83:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  hwtypes/bit_vector.py:576: in __mod__
      return self.bvsrem(other)
  hwtypes/bit_vector.py:132: in wrapped
      return fn(self, other)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

  self = SIntVector[5](30), other = 0

      @bv_cast
      def bvsrem(self, other):
          other = other.as_sint()
  >       return type(self)(self.as_sint() % other)
  E       ZeroDivisionError: integer division or modulo by zero
```

Based on bvsdiv being the same to bvudiv for the other == 0 case, I update bvsrem to return self when other == 0 (as bvurem does).   @cdonovick does the smt lib spec do something different for bvsdiv?