### PR TITLE
Add type string to hash for uniqueness

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -111,7 +111,7 @@ class Bit(AbstractBit):
         return f'{type(self).__name__}({self._value})'
 
     def __hash__(self) -> int:
-        return hash(f"{type(self)}{self._value}")
+        return hash((type(self), self._value))
 
     @classmethod
     def random(cls) -> AbstractBit:

--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -111,7 +111,7 @@ class Bit(AbstractBit):
         return f'{type(self).__name__}({self._value})'
 
     def __hash__(self) -> int:
-        return hash(self._value)
+        return hash(f"{type(self)}{self._value}")
 
     @classmethod
     def random(cls) -> AbstractBit:
@@ -170,7 +170,7 @@ class BitVector(AbstractBitVector):
             return cls.unsized_t[size](value)
 
     def __hash__(self):
-        return hash(self._value)
+        return hash(f"{type(self)}{self._value}")
 
     def __str__(self):
         return str(int(self))

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,14 @@
+from hwtypes import Bit, BitVector, UIntVector, SIntVector
+
+
+def test_hash():
+    x = {
+        Bit(0): 0,
+        BitVector[3](0): 1,
+        UIntVector[3](): 2,
+        SIntVector[3](0): 3,
+    }
+    assert x[Bit(0)] == 0
+    assert x[BitVector[3](0)] == 1
+    assert x[UIntVector[3](0)] == 2
+    assert x[SIntVector[3](0)] == 3


### PR DESCRIPTION
This way BitVector/SIntVector/UIntVector hash to different values,
avoiding collisions (this becomes a problem in magma's cacheing for
generator arguments, because UIntVector and SIntVector of the same
underlying value will hash to the same value, but we actually want them
to dispatch to different generators since one will generate UInt and the
other SInt for the interface types)