### PR TITLE
Set warnings.warn stacklevel to 3

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -140,7 +140,7 @@ class BitVector(AbstractBitVector):
     def __init__(self, value=0):
         if isinstance(value, BitVector):
             if value.size > self.size:
-                warnings.warn('Truncating value from {} to {}'.format(type(value), type(self)))
+                warnings.warn('Truncating value from {} to {}'.format(type(value), type(self)), stacklevel=3)
             value = value._value
         elif isinstance(value, Bit):
             value = int(bool(value))
@@ -151,12 +151,12 @@ class BitVector(AbstractBitVector):
                 #warnings.warn('Truncating value {} to {}'.format(value, type(self)))
         elif isinstance(value, tp.Sequence):
             if len(value) > self.size:
-                warnings.warn('Truncating value {} to {}'.format(value, type(self)))
+                warnings.warn('Truncating value {} to {}'.format(value, type(self)), stacklevel=3)
             value = seq2int(value)
         elif hasattr(value, '__int__'):
             value = int(value)
             if value.bit_length() > self.size:
-                warnings.warn('Truncating value {} to {}'.format(value, type(self)))
+                warnings.warn('Truncating value {} to {}'.format(value, type(self)), stacklevel=3)
         else:
             raise TypeError('Cannot construct {} from {}'.format(type(self), value))
         mask = (1 << self.size) - 1


### PR DESCRIPTION
With this change, instead of a message like this:
```
  /Users/lenny/repos/hwtypes/hwtypes/bit_vector.py:143: UserWarning: Truncating value from <class 'hwtypes.bit_vector.BitVector[32]'> to <class 'hwtypes.bit_vector.BitVector[21]'>
    warnings.warn('Truncating value from {} to {}'.format(type(value), type(self)))
```

we now get something like this:
```
  /Users/lenny/repos/magma_riscv_mini/tests/utils.py:11: UserWarning: Truncating value from <class 'hwtypes.bit_vector.BitVector[32]'> to <class 'hwtypes.bit_vector.BitVector[21]'>
    return BitVector[21](x & ((1 << 20) - 1))
```

which is much more helpful.  We set stacklevel to 3 instead of 2 because
we need to also ignore the metaclass __call__ method, or else we get a
message like this:
```
  /Users/lenny/repos/hwtypes/hwtypes/bit_vector_abc.py:28: UserWarning: Truncating value from <class 'hwtypes.bit_vector.BitVector[32]'> to <class 'hwtypes.bit_vector.BitVector[21]'>
    return super().__call__(value, *args, **kwargs)
```