### PR TITLE
Add repr method

### DIFF
--- a/hwtypes/bit_vector_abc.py
+++ b/hwtypes/bit_vector_abc.py
@@ -118,6 +118,9 @@ class AbstractBitVectorMeta(type): #:(ABCMeta):
         else:
             raise AttributeError('unsized type has no len')
 
+    def __repr__(cls):
+        return cls.__name__
+
 
 class AbstractBit(metaclass=ABCMeta):
     @staticmethod


### PR DESCRIPTION
Prints `BitVector[32]` instead of
`<class 'hwtypes.bit_vector.BitVector[32]'>` which is a bit nicer (more
concise) for debugging.  Especially for adding repr logic to container
classes that implicitly call repr on BV