### PR TITLE
raise TypeError in SMTBit.__bool__

### DIFF
--- a/hwtypes/smt_bit_vector.py
+++ b/hwtypes/smt_bit_vector.py
@@ -152,6 +152,9 @@ class SMTBit(AbstractBit):
             )
         )
 
+    def __bool__(self):
+        raise TypeError('SMTBit cannot be converted to bool')
+
 
 def _coerce(T : tp.Type['SMTBitVector'], val : tp.Any) -> 'SMTBitVector':
     if not isinstance(val, SMTBitVector):

--- a/tests/test_smt_bit.py
+++ b/tests/test_smt_bit.py
@@ -51,3 +51,7 @@ def test_ite_fail():
         res = p.ite(t, f)
 
 
+def test_bool():
+    b = SMTBit()
+    with pytest.raises(TypeError):
+        bool(b)


### PR DESCRIPTION
Objects are by default true which leads to some surprising behavior with SMTBit. https://docs.python.org/3/library/stdtypes.html#truth