### PR TITLE
Enable Structural Pattern Matching for Bit Instances

### DIFF
--- a/hwtypes/bit_vector.py
+++ b/hwtypes/bit_vector.py
@@ -39,6 +39,8 @@ def bit_cast(fn : tp.Callable[['Bit', 'Bit'], 'Bit']) -> tp.Callable[['Bit', tp.
 
 
 class Bit(AbstractBit):
+    __match_args__ = ("value",)  # Enables positional matching
+
     @staticmethod
     def get_family() -> TypeFamily:
         return _Family_
@@ -56,6 +58,10 @@ class Bit(AbstractBit):
             self._value = bool(value)
         else:
             raise TypeError("Can't coerce {} to Bit".format(type(value)))
+
+    @property
+    def value(self):
+        return self._value
 
     def __invert__(self):
         return type(self)(not self._value)


### PR DESCRIPTION
This PR enables support for positional pattern matching on the Bit class using Python's match statement (introduced in Python 3.10 via PEP 634).

With this change, it becomes possible to use concise and readable pattern matching with Bit instances. For example:

```python
bit = Bit(0)
match bit:
    case Bit(0):
        print("Matched 0")
    case Bit(1):
        print("Matched 1")   
```